### PR TITLE
Read @grabl's credentials from environment instead of passing as cmdline

### DIFF
--- a/ci/sync_dependencies.py
+++ b/ci/sync_dependencies.py
@@ -146,7 +146,7 @@ class GitRepo(object):
     GRAKNLABS_PREFIX = 'graknlabs_'
     GRAKN_CORE_REPO_NAME = 'grakn'
     GRAKN_CORE_WORKSPACE = GRAKNLABS_PREFIX + 'grakn_core'
-    GRAKN_AUTHENTICATED_REMOTE_TEMPLATE = 'https://{credential}@github.com/graknlabs/{repo}.git'
+    GRAKN_AUTHENTICATED_REMOTE_TEMPLATE = 'https://$CREDENTIAL@github.com/graknlabs/{repo}.git'
 
     # pylint: disable=line-too-long
     SYNC_MARKER = '# sync-marker: do not remove this comment, this is used for sync-dependencies by @{ws_name}'
@@ -172,6 +172,7 @@ class GitRepo(object):
         else:
             raise ValueError('git coordinates should be in "repo_name" or "repo_name:branch_name" form')
         self.credential = grabl_credential()
+        self.credential_env = {'CREDENTIAL': self.credential}
         self.is_configured = False
         self.clone_dir = None
 
@@ -188,8 +189,7 @@ class GitRepo(object):
     @property
     def remote_url_with_credential(self):
         """ git remote url for authenticated pushing """
-        return self.GRAKN_AUTHENTICATED_REMOTE_TEMPLATE.format(
-            credential=self.credential, repo=self.repo)
+        return self.GRAKN_AUTHENTICATED_REMOTE_TEMPLATE.format(repo=self.repo)
 
     @property
     def marker(self):
@@ -202,10 +202,11 @@ class GitRepo(object):
         if self._last_commit:
             return self._last_commit
         git_output = sp.check_output([
-            'git', 'ls-remote',
-            self.remote_url_with_credential,
-            self.branch
-        ])
+            'bash', '-c',
+            'git ls-remote {} {}'.format(
+                self.remote_url_with_credential,
+                self.branch
+            )], env=self.credential_env)
         self._last_commit = git_output.split()[0]
         return self._last_commit
 
@@ -219,8 +220,9 @@ class GitRepo(object):
         """ clones git repo to a temp directory and returns it; result is cached"""
         temp_dir = tempfile.mkdtemp('.' + self.repo, 'git.')
         sp.check_call([
-            'git', 'clone', self.remote_url_with_credential, temp_dir
-        ])
+            'bash', '-c',
+            'git clone {} {}'.format(self.remote_url_with_credential, temp_dir)
+        ], env=self.credential_env)
         sp.check_call([
             'git', 'checkout', self.branch
         ], cwd=temp_dir)
@@ -257,8 +259,8 @@ class GitRepo(object):
                         stderr=sp.STDOUT)
         print('Pushing the change to {tgt.repo} ({tgt.branch} branch)'.format(tgt=self))
 
-        sp.check_output(["git", "push", self.remote_url_with_credential, self.branch],
-                        cwd=self.clone_dir, stderr=sp.STDOUT)
+        sp.check_output(['bash', '-c' 'git push {} {}'.format(self.remote_url_with_credential, self.branch)],
+                        env=self.credential_env, cwd=self.clone_dir, stderr=sp.STDOUT)
         print('The change has been pushed to {tgt.repo} ({tgt.branch} branch)'.format(tgt=self))
         print()
 

--- a/ci/sync_dependencies.py
+++ b/ci/sync_dependencies.py
@@ -187,7 +187,7 @@ class GitRepo(object):
         return self.GRAKNLABS_PREFIX + self.repo.replace('-', '_')
 
     @property
-    def remote_url_with_credential(self):
+    def remote_url(self):
         """ git remote url for authenticated pushing """
         return self.GRAKN_AUTHENTICATED_REMOTE_TEMPLATE.format(repo=self.repo)
 
@@ -204,7 +204,7 @@ class GitRepo(object):
         git_output = sp.check_output([
             'bash', '-c',
             'git ls-remote {} {}'.format(
-                self.remote_url_with_credential,
+                self.remote_url,
                 self.branch
             )], env=self.credential_env)
         self._last_commit = git_output.split()[0]
@@ -221,7 +221,7 @@ class GitRepo(object):
         temp_dir = tempfile.mkdtemp('.' + self.repo, 'git.')
         sp.check_call([
             'bash', '-c',
-            'git clone {} {}'.format(self.remote_url_with_credential, temp_dir)
+            'git clone {} {}'.format(self.remote_url, temp_dir)
         ], env=self.credential_env)
         sp.check_call([
             'git', 'checkout', self.branch
@@ -259,7 +259,7 @@ class GitRepo(object):
                         stderr=sp.STDOUT)
         print('Pushing the change to {tgt.repo} ({tgt.branch} branch)'.format(tgt=self))
 
-        sp.check_output(['bash', '-c' 'git push {} {}'.format(self.remote_url_with_credential, self.branch)],
+        sp.check_output(['bash', '-c' 'git push {} {}'.format(self.remote_url, self.branch)],
                         env=self.credential_env, cwd=self.clone_dir, stderr=sp.STDOUT)
         print('The change has been pushed to {tgt.repo} ({tgt.branch} branch)'.format(tgt=self))
         print()


### PR DESCRIPTION
- uses $CREDENTIAL instead of passing a command-line argument
- commands have to be prefixed with `bash -c` so variable expansion happens
