### PR TITLE
Improve PackageJsonDependencyReplacer to scan for all package.json-s

### DIFF
--- a/distribution/dependencies.bzl
+++ b/distribution/dependencies.bzl
@@ -22,5 +22,5 @@ def graknlabs_bazel_distribution():
     git_repository(
         name = "graknlabs_bazel_distribution",
         remote = "https://github.com/graknlabs/bazel-distribution",
-        commit = "83469d270e1afa77a2351f6e834991d3a4db342b" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_bazel_distribution
+        commit = "84b2bbaa5c95e5cc255f2ce83dc13a259270322b" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_bazel_distribution
     )


### PR DESCRIPTION
- All `DependencyReplacer::replace` implementations now replace a `list` of replaced files
- `PackageJsonDependencyReplacer` now scans for *all* `package.json` files to replace `client-nodejs` dependency in them