### PR TITLE
release-approval.py - fix working directory issue

### DIFF
--- a/ci/release_approval.py
+++ b/ci/release_approval.py
@@ -48,8 +48,8 @@ while status == 'no-status':
 
     if status == 'deploy':
         print('Release Approval received! Initiating release workflow ...')
-        subprocess.check_output(['git', 'branch', release_branch, 'HEAD'])
-        subprocess.check_output(['git', 'push', 'origin', release_branch + ':' + release_branch])
+        subprocess.check_output(['git', 'branch', release_branch, 'HEAD'], cwd=os.getenv("BUILD_WORKSPACE_DIRECTORY"))
+        subprocess.check_output(['git', 'push', 'origin', release_branch + ':' + release_branch], cwd=os.getenv("BUILD_WORKSPACE_DIRECTORY"))
         print('Initiated the release workflow on {0}/{1}:{2}'.format(organisation, repository, release_branch))
         print('You can monitor it at https://circleci.com/gh/{0}/workflows/{1}/tree/{2}'.format(organisation, repository, release_branch))
     elif status == 'do-not-deploy':


### PR DESCRIPTION
`release-approval.py` will fail because it is run from within the Bazel sandbox and won't have access to the workspace. This PR fixes the issue.

Here's an example of the error which was encountered when making a release draft for Workbase:

https://circleci.com/gh/graknlabs/workbase/678

```
Tests have been ran and everything is in a good, releasable state. It is possible to proceed with the release process. Waiting for approval.
..................................Release Approval received! Initiating release workflow ...
fatal: Not a git repository (or any of the parent directories): .git
Traceback (most recent call last):
  File "/home/circleci/.cache/bazel/_bazel_circleci/f16e36219ef33c22efc2ad20f3e3775c/execroot/graknlabs_workbase/bazel-out/k8-fastbuild/bin/external/graknlabs_build_tools/ci/release-approval.runfiles/graknlabs_build_tools/ci/release_approval.py", line 51, in <module>
    subprocess.check_output(['git', 'branch', release_branch, 'HEAD'])
  File "/opt/circleci/.pyenv/versions/2.7.12/lib/python2.7/subprocess.py", line 574, in check_output
    raise CalledProcessError(retcode, cmd, output=output)
subprocess.CalledProcessError: Command '['git', 'branch', 'workbase-release-branch', 'HEAD']' returned non-zero exit status 128`
```