### PR TITLE
Update bazel-distribution

### DIFF
--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -22,5 +22,5 @@ def graknlabs_bazel_distribution():
     git_repository(
         name = "graknlabs_bazel_distribution",
         remote = "https://github.com/graknlabs/bazel-distribution",
-        commit = "6da3ad26a8fa4628241249fbef94392f78f89b23" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_bazel_distribution
+        commit = "249ee1e24e95b1744bddcd8dbf2a794bdfba1f93" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_bazel_distribution
     )


### PR DESCRIPTION
Update bazel-distribution to the version which contains the new implementation of `deploy_brew`