### PR TITLE
Remove obsolete property keys

### DIFF
--- a/deployment.properties
+++ b/deployment.properties
@@ -16,14 +16,11 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-repo.github.organisation=graknlabs
-repo.github.repository=grakn
 repo.maven.snapshot=https://repo.grakn.ai/repository/test-maven/
 repo.maven.release=https://repo.grakn.ai/repository/maven/
 repo.pypi.pypi=https://upload.pypi.org/legacy/
 repo.npm.npmjs=https://registry.npmjs.org/
 repo.npm.test=https://repo.grakn.ai/repository/test-npm/
-repo.pypi.tpypi=https://test.pypi.org/legacy/
 repo.pypi.test=https://repo.grakn.ai/repository/test-pypi/
 repo.rpm.test=https://repo.grakn.ai/repository/test-rpm/
 repo.apt.test=https://repo.grakn.ai/repository/test-deb/


### PR DESCRIPTION
These keys are no longer relevant

`repo.github.*` — not common across multiple repos
`repo.pypi.tpypi` — we use our test repo instead of test PyPI