### PR TITLE
Test credentials in place of production URLs

### DIFF
--- a/deployment.properties
+++ b/deployment.properties
@@ -16,15 +16,28 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-repo.maven.snapshot=https://repo.grakn.ai/repository/test-maven/
-repo.maven.release=https://repo.grakn.ai/repository/maven/
-repo.pypi.pypi=https://upload.pypi.org/legacy/
-repo.npm.npmjs=https://registry.npmjs.org/
-repo.npm.test=https://repo.grakn.ai/repository/test-npm/
-repo.pypi.test=https://repo.grakn.ai/repository/test-pypi/
-repo.rpm.test=https://repo.grakn.ai/repository/test-rpm/
 repo.apt.test=https://repo.grakn.ai/repository/test-deb/
+#repo.apt.release=https://repo.grakn.ai/repository/deb/
+repo.apt.release=https://repo.grakn.ai/repository/test-deb/
+
 repo.brew.test=https://github.com/graknlabs/homebrew-tap-test/
-repo.brew.release=https://github.com/graknlabs/homebrew-tap/
+#repo.brew.release=https://github.com/graknlabs/homebrew-tap/
+repo.brew.release=https://github.com/graknlabs/homebrew-tap-test/
+
+repo.maven.snapshot=https://repo.grakn.ai/repository/test-maven/
+#repo.maven.release=https://repo.grakn.ai/repository/maven/
+repo.maven.release=https://repo.grakn.ai/repository/test-maven/
+
+#repo.pypi.pypi=https://upload.pypi.org/legacy/
+repo.pypi.pypi=https://repo.grakn.ai/repository/test-pypi/
+repo.pypi.test=https://repo.grakn.ai/repository/test-pypi/
+
+#repo.npm.npmjs=https://registry.npmjs.org/
+repo.npm.npmjs=https://repo.grakn.ai/repository/test-npm/
+repo.npm.test=https://repo.grakn.ai/repository/test-npm/
+
+repo.rpm.test=https://repo.grakn.ai/repository/test-rpm/
+#repo.rpm.release=https://repo.grakn.ai/repository/rpm/
+repo.rpm.release=https://repo.grakn.ai/repository/test-rpm/
 
 maven.packages=api,client-java,common,concept,console,daemon,java,protocol,server


### PR DESCRIPTION
This switches `*.release` keys to have `*.test` values whereas preserving old values in comment