### PR TITLE
Add benchmark:master to sync dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
           --source build-tools@$CIRCLE_SHA1 \
           --targets \
           graql:master grakn:master workbase:master docs:development examples:development \
-          client-java:master client-python:master client-nodejs:master
+          client-java:master client-python:master client-nodejs:master benchmark:master
 
 workflows:
   build-tools:


### PR DESCRIPTION
## What is the goal of this PR?

Auto-update benchmark dependencies to reflect updates to build-tools. This should lead to notifications when benchmark fails because of a breaking change rather than having to notice that the dashboard is not updating anymore.

## What are the changes implemented in this PR?
* Add benchmark:master to sync dependencies
