### PR TITLE
CI: sync-dependencies now syncs to grakn-kgms

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,9 +51,8 @@ jobs:
           bazel run //ci:sync-dependencies -- \
           --source build-tools@$CIRCLE_SHA1 \
           --targets \
-          graql:master grakn:master grakn-kgms:master \
+          graql:master grakn:master grakn-kgms:master workbase:master benchmark:master \
           client-java:master client-python:master client-nodejs:master \
-          workbase:master benchmark:master \
           docs:development examples:development
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,8 +51,10 @@ jobs:
           bazel run //ci:sync-dependencies -- \
           --source build-tools@$CIRCLE_SHA1 \
           --targets \
-          graql:master grakn:master workbase:master docs:development examples:development \
-          client-java:master client-python:master client-nodejs:master benchmark:master
+          graql:master grakn:master grakn-kgms:master \
+          client-java:master client-python:master client-nodejs:master \
+          workbase:master benchmark:master \
+          docs:development examples:development
 
 workflows:
   build-tools:


### PR DESCRIPTION
## What is the goal of this PR?

`sync-dependencies` now syncs to grakn-kgms.

Additionally, the ordering of the arguments has been tidied up: the first line contains the top-level products, the second line contains the client drivers, and the third documentations.