### PR TITLE
Improve error reporting and remove the need to supply SSH keys

### DIFF
--- a/checkstyle/test-coverage.py
+++ b/checkstyle/test-coverage.py
@@ -21,13 +21,13 @@
 from __future__ import print_function
 import os
 from xml.etree import ElementTree
-import subprocess
+import subprocess as sp
 import sys
 
 
-def check_output_discarding_stderr(*args, **kwargs):
+def shell_execute(*args, **kwargs):
     with open(os.devnull, 'w') as devnull:
-        output = subprocess.check_output(*args, cwd=os.getenv("BUILD_WORKSPACE_DIRECTORY"), stderr=devnull, **kwargs)
+        output = sp.check_output(*args, cwd=os.getenv("BUILD_WORKSPACE_DIRECTORY"), stderr=sp.STDOUT, **kwargs)
         if type(output) == bytes:
             output = output.decode()
         return output
@@ -41,13 +41,13 @@ def try_decode(s):
 
 print('Checking if there are any source files not covered by checkstyle...')
 
-java_targets = check_output_discarding_stderr([
+java_targets = shell_execute([
     'bazel', 'query',
     '(kind(java_library, //...) union kind(java_test, //...)) '
     'except //dependencies/... except attr("tags", "checkstyle_ignore", //...)'
 ]).split()
 
-checkstyle_targets_xml = check_output_discarding_stderr([
+checkstyle_targets_xml = shell_execute([
     'bazel', 'query', 'kind(checkstyle_test, //...)', '--output', 'xml'
 ])
 checkstyle_targets_tree = ElementTree.fromstring(checkstyle_targets_xml)

--- a/ci/release-approval.py
+++ b/ci/release-approval.py
@@ -3,7 +3,7 @@
 from __future__ import print_function
 
 import os
-import subprocess
+import subprocess as sp
 import json
 import time
 import sys
@@ -30,11 +30,11 @@ if git_token is None:
 def check_output_discarding_stderr(*args, **kwargs):
     with open(os.devnull, 'w') as devnull:
         try:
-            output = subprocess.check_output(*args, stderr=devnull, **kwargs)
+            output = sp.check_output(*args, stderr=sp.STDOUT, **kwargs)
             if type(output) == bytes:
                 output = output.decode()
             return output
-        except subprocess.CalledProcessError as e:
+        except sp.CalledProcessError as e:
             print('An error occurred when running "' + str(e.cmd) + '". Process exited with code ' + str(
                 e.returncode) + ' and message "' + e.output + '"')
             raise e
@@ -68,8 +68,8 @@ while status == 'no-status':
         release_branch = repository + '-release-branch'
 
         print('Release Approval received! Initiating release workflow ...')
-        subprocess.check_output(['git', 'branch', release_branch, 'HEAD'], cwd=os.getenv("BUILD_WORKSPACE_DIRECTORY"))
-        subprocess.check_output(['git', 'push', '{0}:{1}@github.com/{2}/{3}.git'.format(git_username, git_token, organisation, repository), release_branch], cwd=os.getenv("BUILD_WORKSPACE_DIRECTORY"))
+        sp.check_output(['git', 'branch', release_branch, 'HEAD'], cwd=os.getenv("BUILD_WORKSPACE_DIRECTORY"))
+        sp.check_output(['git', 'push', '{0}:{1}@github.com/{2}/{3}.git'.format(git_username, git_token, organisation, repository), release_branch], cwd=os.getenv("BUILD_WORKSPACE_DIRECTORY"))
         print('Initiated the release workflow on {0}/{1}:{2}'.format(organisation, repository, release_branch))
         print('You can monitor it at https://circleci.com/gh/{0}/workflows/{1}/tree/{2}'.format(organisation, repository, release_branch))
     elif status == 'do-not-deploy':

--- a/ci/release-approval.py
+++ b/ci/release-approval.py
@@ -82,5 +82,5 @@ while status == 'no-status':
     # print '...' to provide a visual indication that it's waiting for an input
     sys.stdout.write('.')
     sys.stdout.flush()
-
+    print('-- {}'.format(status))
     time.sleep(1)

--- a/ci/release-approval.py
+++ b/ci/release-approval.py
@@ -20,7 +20,7 @@ if not IS_CIRCLE_ENV:
     GRABL_HOST = 'http://localhost:8000'
 
 git_username = os.environ['RELEASE_APPROVAL_USERNAME']
-if git_token is None:
+if git_username is None:
     raise Exception('Environment variable $RELEASE_APPROVAL_USERNAME is not set!')
 
 git_token = os.getenv('RELEASE_APPROVAL_TOKEN')

--- a/ci/release-approval.py
+++ b/ci/release-approval.py
@@ -53,14 +53,14 @@ new_release_signature = hmac.new(git_token, json.dumps(grabl_data), hashlib.sha1
 print("Tests have been ran and everything is in a good, releasable state. "
     "It is possible to proceed with the release process. Waiting for approval.")
 check_output_discarding_stderr([
-    'curl', '-X', 'POST', '--data', json.dumps(grabl_data), '-H', 'Content-Type: application/json', '-H', 'X-Hub-Signature: ' + new_release_signature, grabl_url_new
+    'curl', '--fail', '-X', 'POST', '--data', json.dumps(grabl_data), '-H', 'Content-Type: application/json', '-H', 'X-Hub-Signature: ' + new_release_signature, grabl_url_new
 ])
 
 status = 'no-status'
 
 while status == 'no-status':
     get_release_status_signature = hmac.new(git_token, '', hashlib.sha1).hexdigest()
-    status = check_output_discarding_stderr(['curl', '-H', 'X-Hub-Signature: ' + get_release_status_signature, grabl_url_status])
+    status = check_output_discarding_stderr(['curl', '--fail', '-H', 'X-Hub-Signature: ' + get_release_status_signature, grabl_url_status])
 
     if status == 'deploy':
         organisation = os.getenv('CIRCLE_PROJECT_USERNAME')

--- a/ci/release-approval.py
+++ b/ci/release-approval.py
@@ -19,10 +19,13 @@ GRABL_HOST = 'https://grabl.grakn.ai'
 if not IS_CIRCLE_ENV:
     GRABL_HOST = 'http://localhost:8000'
 
+git_username = os.environ['RELEASE_APPROVAL_USERNAME']
+if git_token is None:
+    raise Exception('Environment variable $RELEASE_APPROVAL_USERNAME is not set!')
+
 git_token = os.getenv('RELEASE_APPROVAL_TOKEN')
 if git_token is None:
     raise Exception('Environment variable $RELEASE_APPROVAL_TOKEN is not set!')
-
 
 def check_output_discarding_stderr(*args, **kwargs):
     with open(os.devnull, 'w') as devnull:
@@ -66,7 +69,7 @@ while status == 'no-status':
 
         print('Release Approval received! Initiating release workflow ...')
         subprocess.check_output(['git', 'branch', release_branch, 'HEAD'], cwd=os.getenv("BUILD_WORKSPACE_DIRECTORY"))
-        subprocess.check_output(['git', 'push', 'origin', release_branch + ':' + release_branch], cwd=os.getenv("BUILD_WORKSPACE_DIRECTORY"))
+        subprocess.check_output(['git', 'push', '{0}:{1}@github.com/{2}/{3}.git'.format(git_username, git_token, organisation, repository), release_branch], cwd=os.getenv("BUILD_WORKSPACE_DIRECTORY"))
         print('Initiated the release workflow on {0}/{1}:{2}'.format(organisation, repository, release_branch))
         print('You can monitor it at https://circleci.com/gh/{0}/workflows/{1}/tree/{2}'.format(organisation, repository, release_branch))
     elif status == 'do-not-deploy':

--- a/ci/release-approval.py
+++ b/ci/release-approval.py
@@ -19,7 +19,7 @@ GRABL_HOST = 'https://grabl.grakn.ai'
 if not IS_CIRCLE_ENV:
     GRABL_HOST = 'http://localhost:8000'
 
-git_username = os.environ['RELEASE_APPROVAL_USERNAME']
+git_username = os.getenv('RELEASE_APPROVAL_USERNAME')
 if git_username is None:
     raise Exception('Environment variable $RELEASE_APPROVAL_USERNAME is not set!')
 

--- a/ci/sync-dependencies.py
+++ b/ci/sync-dependencies.py
@@ -132,7 +132,7 @@ def main():
 
     print('Sending post request to: ' + GRABL_SYNC_DEPS)
     check_output_discarding_stderr([
-        'curl', '-X', 'POST', '--data', sync_data_json, '-H', 'Content-Type: application/json', '-H', 'X-Hub-Signature: ' + signature, GRABL_SYNC_DEPS
+        'curl', '--fail', '-X', 'POST', '--data', sync_data_json, '-H', 'Content-Type: application/json', '-H', 'X-Hub-Signature: ' + signature, GRABL_SYNC_DEPS
     ])
     print('DONE!')
 

--- a/ci/sync-dependencies.py
+++ b/ci/sync-dependencies.py
@@ -14,7 +14,7 @@ from __future__ import print_function
 import argparse
 import json
 import os
-import subprocess
+import subprocess as sp
 import sys
 import github
 import hashlib
@@ -60,7 +60,7 @@ def exception_handler(fun):
         # pylint: disable=missing-docstring
         try:
             fun(*args, **kwargs)
-        except subprocess.CalledProcessError as ex:
+        except sp.CalledProcessError as ex:
             print('An error occurred when running {ex.cmd}. '
                   'Process exited with code {ex.returncode} '
                   'and message {ex.output}'.format(ex=ex))
@@ -70,21 +70,21 @@ def exception_handler(fun):
     return wrapper
 
 
-def check_output_discarding_stderr(*args, **kwargs):
+def shell_execute(*args, **kwargs):
     with open(os.devnull, 'w') as devnull:
         try:
-            output = subprocess.check_output(*args, stderr=devnull, **kwargs)
+            output = sp.check_output(*args, stderr=sp.STDOUT, **kwargs)
             if type(output) == bytes:
                 output = output.decode()
             return output
-        except subprocess.CalledProcessError as e:
+        except sp.CalledProcessError as e:
             print('An error occurred when running "' + str(e.cmd) + '". Process exited with code ' + str(
                 e.returncode) + ' and message "' + e.output + '"')
             raise e
 
 
 def short_commit(commit_sha):
-    return subprocess.check_output(['git', 'rev-parse', '--short=7', commit_sha],
+    return sp.check_output(['git', 'rev-parse', '--short=7', commit_sha],
                                    cwd=os.getenv("BUILD_WORKSPACE_DIRECTORY")).decode().replace('\n', '')
 
 
@@ -131,7 +131,7 @@ def main():
     signature = hmac.new(GRABL_TOKEN, sync_data_json, hashlib.sha1).hexdigest()
 
     print('Sending post request to: ' + GRABL_SYNC_DEPS)
-    check_output_discarding_stderr([
+    shell_execute([
         'curl', '--fail', '-X', 'POST', '--data', sync_data_json, '-H', 'Content-Type: application/json', '-H', 'X-Hub-Signature: ' + signature, GRABL_SYNC_DEPS
     ])
     print('DONE!')


### PR DESCRIPTION
Improve error reporting in `test-coverage.py`, `release-approval.py`, and `sync-dependencies.py` in the following ways:
- Ensure `stderr` is captured and not discarded which will make debugging much easier.
- Eliminate various scenarios where the script can fail silently when making a failed HTTP request due to incorrect credentials.

`release-approval.py` has been updated to accept Github username and token which can be supplied via the `$RELEASE_APPROVAL_USERNAME` and `$RELEASE_APPROVAL_TOKEN` environment variables. This is an improvement to the old approach of needing SSH keys which is more cumbersome to generate and supply.

Closes https://github.com/graknlabs/build-tools/issues/34 and https://github.com/graknlabs/build-tools/issues/35