### PR TITLE
Introduces `common.py` to hold functions used across the codebase. `shell_execute` no longer merges stderr into stdout

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -32,3 +32,9 @@ platform(
         }
         """,
 )
+
+py_library(
+    name = "common",
+    srcs = ["common.py"],
+    visibility = ["//visibility:public"]
+)

--- a/checkstyle/BUILD
+++ b/checkstyle/BUILD
@@ -19,5 +19,6 @@
 py_binary(
     name = "test-coverage",
     srcs = ["test-coverage.py"],
-    main = "test-coverage.py"
+    main = "test-coverage.py",
+    deps = ["//:common"]
 )

--- a/checkstyle/test-coverage.py
+++ b/checkstyle/test-coverage.py
@@ -34,13 +34,13 @@ def try_decode(s):
 
 print('Checking if there are any source files not covered by checkstyle...')
 
-java_targets = common.shell_execute([
+java_targets, _ = common.shell_execute([
     'bazel', 'query',
     '(kind(java_library, //...) union kind(java_test, //...)) '
     'except //dependencies/... except attr("tags", "checkstyle_ignore", //...)'
 ]).split()
 
-checkstyle_targets_xml = common.shell_execute([
+checkstyle_targets_xml, _ = common.shell_execute([
     'bazel', 'query', 'kind(checkstyle_test, //...)', '--output', 'xml'
 ])
 checkstyle_targets_tree = ElementTree.fromstring(checkstyle_targets_xml)

--- a/checkstyle/test-coverage.py
+++ b/checkstyle/test-coverage.py
@@ -20,10 +20,8 @@
 
 from __future__ import print_function
 import common
-import os
-from xml.etree import ElementTree
-import subprocess as sp
 import sys
+from xml.etree import ElementTree
 
 
 def try_decode(s):
@@ -32,40 +30,41 @@ def try_decode(s):
     return s
 
 
-print('Checking if there are any source files not covered by checkstyle...')
+if __name__ == '__main__':
+    print('Checking if there are any source files not covered by checkstyle...')
 
-java_targets, _ = common.shell_execute([
-    'bazel', 'query',
-    '(kind(java_library, //...) union kind(java_test, //...)) '
-    'except //dependencies/... except attr("tags", "checkstyle_ignore", //...)'
-]).split()
+    java_targets, _ = common.shell_execute([
+        'bazel', 'query',
+        '(kind(java_library, //...) union kind(java_test, //...)) '
+        'except //dependencies/... except attr("tags", "checkstyle_ignore", //...)'
+    ], cwd='/Users/lolski/grakn.ai/grakn') # ], cwd=os.getenv("BUILD_WORKSPACE_DIRECTORY"))
+    java_targets = java_targets.split()
 
-checkstyle_targets_xml, _ = common.shell_execute([
-    'bazel', 'query', 'kind(checkstyle_test, //...)', '--output', 'xml'
-])
-checkstyle_targets_tree = ElementTree.fromstring(checkstyle_targets_xml)
-java_targets_covered_by_target_attr = checkstyle_targets_tree.findall(".//label[@name='target'][@value]")
-java_targets_covered_by_targets_attr = checkstyle_targets_tree.findall(".//list[@name='targets']//label[@value]")
-checkstyle_targets = list(map(
-    lambda x: x.get('value'), java_targets_covered_by_target_attr + java_targets_covered_by_targets_attr))
-unique_checkstyle_targets = set(checkstyle_targets)
+    checkstyle_targets_xml, _ = common.shell_execute([
+        'bazel', 'query', 'kind(checkstyle_test, //...)', '--output', 'xml'
+    ], cwd='/Users/lolski/grakn.ai/grakn') # ], cwd=os.getenv("BUILD_WORKSPACE_DIRECTORY"))
+    checkstyle_targets_tree = ElementTree.fromstring(checkstyle_targets_xml)
+    java_targets_covered_by_target_attr = checkstyle_targets_tree.findall(".//label[@name='target'][@value]")
+    java_targets_covered_by_targets_attr = checkstyle_targets_tree.findall(".//list[@name='targets']//label[@value]")
+    checkstyle_targets = list(map(
+        lambda x: x.get('value'), java_targets_covered_by_target_attr + java_targets_covered_by_targets_attr))
+    unique_checkstyle_targets = set(checkstyle_targets)
 
-if len(unique_checkstyle_targets) != len(checkstyle_targets):
-    non_unique_checkstyle_target = set([x for x in checkstyle_targets if checkstyle_targets.count(x) > 1])
-    non_unique_checkstyle_target_count = len(non_unique_checkstyle_target)
-    print('ERROR: Found %d bazel targets which are covered more than once:' % non_unique_checkstyle_target_count)
-    for i, target_label in enumerate(non_unique_checkstyle_target, start=1):
-        print('%d: %s' % (i, target_label))
-    sys.exit(1)
+    if len(unique_checkstyle_targets) != len(checkstyle_targets):
+        non_unique_checkstyle_target = set([x for x in checkstyle_targets if checkstyle_targets.count(x) > 1])
+        non_unique_checkstyle_target_count = len(non_unique_checkstyle_target)
+        print('ERROR: Found %d bazel targets which are covered more than once:' % non_unique_checkstyle_target_count)
+        for i, target_label in enumerate(non_unique_checkstyle_target, start=1):
+            print('%d: %s' % (i, target_label))
+        sys.exit(1)
 
+    java_targets_with_no_checkstyle = set(java_targets) - set(checkstyle_targets)
+    target_count = len(java_targets_with_no_checkstyle)
 
-java_targets_with_no_checkstyle = set(java_targets) - set(checkstyle_targets)
-target_count = len(java_targets_with_no_checkstyle)
-
-if java_targets_with_no_checkstyle:
-    print('ERROR: Found %d bazel targets which are not covered by a `checkstyle_test`:' % target_count)
-    for i, target_label in enumerate(java_targets_with_no_checkstyle, start=1):
-        print('%d: %s' % (i, target_label))
-    sys.exit(1)
-else:
-    print('SUCCESS: Every source code is covered by a `checkstyle_test`!')
+    if java_targets_with_no_checkstyle:
+        print('ERROR: Found %d bazel targets which are not covered by a `checkstyle_test`:' % target_count)
+        for i, target_label in enumerate(java_targets_with_no_checkstyle, start=1):
+            print('%d: %s' % (i, target_label))
+        sys.exit(1)
+    else:
+        print('SUCCESS: Every source code is covered by a `checkstyle_test`!')

--- a/checkstyle/test-coverage.py
+++ b/checkstyle/test-coverage.py
@@ -19,18 +19,11 @@
 #
 
 from __future__ import print_function
+import common
 import os
 from xml.etree import ElementTree
 import subprocess as sp
 import sys
-
-
-def shell_execute(*args, **kwargs):
-    with open(os.devnull, 'w') as devnull:
-        output = sp.check_output(*args, cwd=os.getenv("BUILD_WORKSPACE_DIRECTORY"), stderr=devnull, **kwargs)
-        if type(output) == bytes:
-            output = output.decode()
-        return output
 
 
 def try_decode(s):
@@ -41,13 +34,13 @@ def try_decode(s):
 
 print('Checking if there are any source files not covered by checkstyle...')
 
-java_targets = shell_execute([
+java_targets = common.shell_execute([
     'bazel', 'query',
     '(kind(java_library, //...) union kind(java_test, //...)) '
     'except //dependencies/... except attr("tags", "checkstyle_ignore", //...)'
 ]).split()
 
-checkstyle_targets_xml = shell_execute([
+checkstyle_targets_xml = common.shell_execute([
     'bazel', 'query', 'kind(checkstyle_test, //...)', '--output', 'xml'
 ])
 checkstyle_targets_tree = ElementTree.fromstring(checkstyle_targets_xml)

--- a/checkstyle/test-coverage.py
+++ b/checkstyle/test-coverage.py
@@ -20,6 +20,7 @@
 
 from __future__ import print_function
 import common
+import os
 import sys
 from xml.etree import ElementTree
 
@@ -37,12 +38,12 @@ if __name__ == '__main__':
         'bazel', 'query',
         '(kind(java_library, //...) union kind(java_test, //...)) '
         'except //dependencies/... except attr("tags", "checkstyle_ignore", //...)'
-    ], cwd='/Users/lolski/grakn.ai/grakn') # ], cwd=os.getenv("BUILD_WORKSPACE_DIRECTORY"))
+    ], cwd=os.getenv("BUILD_WORKSPACE_DIRECTORY"))
     java_targets = java_targets.split()
 
     checkstyle_targets_xml, _ = common.shell_execute([
         'bazel', 'query', 'kind(checkstyle_test, //...)', '--output', 'xml'
-    ], cwd='/Users/lolski/grakn.ai/grakn') # ], cwd=os.getenv("BUILD_WORKSPACE_DIRECTORY"))
+    ], cwd=os.getenv("BUILD_WORKSPACE_DIRECTORY"))
     checkstyle_targets_tree = ElementTree.fromstring(checkstyle_targets_xml)
     java_targets_covered_by_target_attr = checkstyle_targets_tree.findall(".//label[@name='target'][@value]")
     java_targets_covered_by_targets_attr = checkstyle_targets_tree.findall(".//list[@name='targets']//label[@value]")

--- a/ci/BUILD
+++ b/ci/BUILD
@@ -24,6 +24,7 @@ py_binary(
     srcs = ["sync-dependencies.py"],
     main = "sync-dependencies.py",
     deps = [
+        "//:common",
         requirement("PyGithub"),
         requirement("urllib3"),
         requirement("chardet"),
@@ -42,7 +43,8 @@ py_binary(
 py_binary(
     name = "release-approval",
     srcs = ["release-approval.py"],
-    main = "release-approval.py"
+    main = "release-approval.py",
+    deps = [ "//:common"]
 )
 
 sh_binary(

--- a/ci/release-approval.py
+++ b/ci/release-approval.py
@@ -49,7 +49,7 @@ status = 'no-status'
 
 while status == 'no-status':
     get_release_status_signature = hmac.new(git_token, '', hashlib.sha1).hexdigest()
-    status = common.shell_execute(['curl', '--silent', '--show-error', '--fail', '-H', 'X-Hub-Signature: ' + get_release_status_signature, grabl_url_status])
+    status, _ = common.shell_execute(['curl', '--silent', '--show-error', '--fail', '-H', 'X-Hub-Signature: ' + get_release_status_signature, grabl_url_status])
 
     if status == 'deploy':
         organisation = os.getenv('CIRCLE_PROJECT_USERNAME')

--- a/ci/release-approval.py
+++ b/ci/release-approval.py
@@ -58,7 +58,9 @@ while status == 'no-status':
 
         print('Release Approval received! Initiating release workflow ...')
         sp.check_output(['git', 'branch', release_branch, 'HEAD'], cwd=os.getenv("BUILD_WORKSPACE_DIRECTORY"))
-        sp.check_output(['git', 'push', 'https://{0}:{1}@github.com/{2}/{3}.git'.format(git_username, git_token, organisation, repository), release_branch], cwd=os.getenv("BUILD_WORKSPACE_DIRECTORY"))
+        sp.check_output(['bash', '-c', 'git push https://{0}:{1}@github.com/{2}/{3}.git {4}'
+                        .format(git_username, git_token, organisation, repository, release_branch)],
+                        cwd=os.getenv("BUILD_WORKSPACE_DIRECTORY"))
         print('Initiated the release workflow on {0}/{1}:{2}'.format(organisation, repository, release_branch))
         print('You can monitor it at https://circleci.com/gh/{0}/workflows/{1}/tree/{2}'.format(organisation, repository, release_branch))
     elif status == 'do-not-deploy':

--- a/ci/sync-dependencies.py
+++ b/ci/sync-dependencies.py
@@ -12,14 +12,15 @@ bazel run @graknlabs_build_tools//ci:sync-dependencies -- \
 from __future__ import print_function
 
 import argparse
-import json
-import os
-import subprocess as sp
-import sys
+import common
 import github
 import hashlib
 import hmac
+import json
+import os
 import re
+import subprocess as sp
+import sys
 
 
 IS_CIRCLE_ENV = os.getenv('CIRCLECI')
@@ -71,19 +72,6 @@ def exception_handler(fun):
             raise ex
 
     return wrapper
-
-
-def shell_execute(*args, **kwargs):
-    with open(os.devnull, 'w') as devnull:
-        try:
-            output = sp.check_output(*args, stderr=sp.STDOUT, **kwargs)
-            if type(output) == bytes:
-                output = output.decode()
-            return output
-        except sp.CalledProcessError as e:
-            print('An error occurred when running "' + str(e.cmd) + '". Process exited with code ' + str(
-                e.returncode) + ' and message "' + e.output + '"')
-            raise e
 
 
 def short_commit(commit_sha):
@@ -140,7 +128,7 @@ def main():
     signature = hmac.new(GRABL_TOKEN, sync_data_json, hashlib.sha1).hexdigest()
 
     print('Sending post request to: ' + GRABL_SYNC_DEPS)
-    shell_execute([
+    common.shell_execute([
         'curl', '-X', 'POST', '--data', sync_data_json, '-H', 'Content-Type: application/json', '-H', 'X-Hub-Signature: ' + signature, GRABL_SYNC_DEPS
         # 'curl', '--silent', '--show-error', '--fail', '-X', 'POST', '--data', sync_data_json, '-H', 'Content-Type: application/json', '-H', 'X-Hub-Signature: ' + signature, GRABL_SYNC_DEPS
     ])

--- a/common.py
+++ b/common.py
@@ -21,12 +21,11 @@ def shell_execute(args, **kwargs):
             err = err.decode()
 
         if process.returncode == 0:
-            print('cmd = {}\nout = {}\nerr = {}'.format(args, out, err))
             return out, err
         else:
             raise RuntimeError('An error occurred.\n' +
                                '- Command = "'+ str(args) + '"\n' +
                                '- Exit code = "' + str(process.returncode) + '"\n' +
-                               '- Working directory = "' + str(cwd) + '"\n' +
+                               '- Working directory = "' + str(os.getcwd()) + '"\n' +
                                '- stdout = "' + out + '"\n' +
                                '- stderr = "' + err + '"\n')

--- a/common.py
+++ b/common.py
@@ -2,14 +2,19 @@ import os
 import subprocess as sp
 
 
-def shell_execute(*args, **kwargs):
-    with open(os.devnull, 'w') as devnull:
-        try:
-            output = sp.check_output(*args, stderr=sp.STDOUT, **kwargs)
-            if type(output) == bytes:
-                output = output.decode()
-            return output
-        except sp.CalledProcessError as e:
-            print('An error occurred when running "' + str(e.cmd) + '". Process exited with code ' + str(
-                e.returncode) + ' and message "' + e.output + '"')
-            raise e
+def shell_execute(*args):
+    p = sp.Popen(args, stdout=sp.PIPE, stderr=sp.PIPE)
+    p.wait()
+    out = p.stdout.read()
+    err = p.stderr.read()
+    if p.returncode == 0:
+        if type(out) == bytes:
+            out = out.decode()
+        if type(err) == bytes:
+            err = err.decode()
+        return out, err
+    else:
+        raise RuntimeError('An error occurred when running "' + str(' '.join(args)) + '"\n' +
+                           'Exit code = "' + str(p.returncode) + '"\n' +
+                           'stdout = "' + out + '"\n' +
+                           'stderr = "' + err + '"\n')

--- a/common.py
+++ b/common.py
@@ -1,20 +1,32 @@
 import os
 import subprocess as sp
+import tempfile
 
 
-def shell_execute(*args):
-    p = sp.Popen(args, stdout=sp.PIPE, stderr=sp.PIPE)
-    p.wait()
-    out = p.stdout.read()
-    err = p.stderr.read()
-    if p.returncode == 0:
+def shell_execute(args, **kwargs):
+    with tempfile.NamedTemporaryFile(delete = True) as tmpstdout, \
+            tempfile.NamedTemporaryFile(delete = True) as tmpstderr:
+
+        process = sp.Popen(args, stdout=tmpstdout, stderr=tmpstderr, **kwargs)
+        process.wait()
+
+        tmpstdout.seek(0)
+        out = tmpstdout.read()
         if type(out) == bytes:
             out = out.decode()
+
+        tmpstderr.seek(0)
+        err = tmpstderr.read()
         if type(err) == bytes:
             err = err.decode()
-        return out, err
-    else:
-        raise RuntimeError('An error occurred when running "' + str(' '.join(args)) + '"\n' +
-                           'Exit code = "' + str(p.returncode) + '"\n' +
-                           'stdout = "' + out + '"\n' +
-                           'stderr = "' + err + '"\n')
+
+        if process.returncode == 0:
+            print('cmd = {}\nout = {}\nerr = {}'.format(args, out, err))
+            return out, err
+        else:
+            raise RuntimeError('An error occurred.\n' +
+                               '- Command = "'+ str(args) + '"\n' +
+                               '- Exit code = "' + str(process.returncode) + '"\n' +
+                               '- Working directory = "' + str(cwd) + '"\n' +
+                               '- stdout = "' + out + '"\n' +
+                               '- stderr = "' + err + '"\n')

--- a/common.py
+++ b/common.py
@@ -1,0 +1,15 @@
+import os
+import subprocess as sp
+
+
+def shell_execute(*args, **kwargs):
+    with open(os.devnull, 'w') as devnull:
+        try:
+            output = sp.check_output(*args, stderr=sp.STDOUT, **kwargs)
+            if type(output) == bytes:
+                output = output.decode()
+            return output
+        except sp.CalledProcessError as e:
+            print('An error occurred when running "' + str(e.cmd) + '". Process exited with code ' + str(
+                e.returncode) + ' and message "' + e.output + '"')
+            raise e


### PR DESCRIPTION
Introduces `common.py` to hold functions used across the codebase. This should reduce code duplication and make the codebase more maintainable

`shell_execute` no longer merges stderr into stdout. Instead it returns `stdout` and `stderr` in a separate variables. If exit code is non-zero, it will throw / raise a `RuntimeError`:
```
try:
    stdout, stderr = common.shell_execute(['bazel', 'test', '//...'])
except RuntimeError:
    ...
```