### PR TITLE
Implement sync-version tools

### DIFF
--- a/ci/BUILD
+++ b/ci/BUILD
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-exports_files(["requirements.txt"])
+exports_files(["requirements.txt", "sync-version.py"])
 load("@graknlabs_build_tools_ci_pip//:requirements.bzl", "requirement")
 
 py_binary(

--- a/ci/sync-version.py
+++ b/ci/sync-version.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+
+#
+# GRAKN.AI - THE KNOWLEDGE GRAPH
+# Copyright (C) 2018 Grakn Labs Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+import sys
+import logging
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(
+    format='[%(asctime)s.%(msecs)03d]: %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S',
+)
+logger.level = logging.DEBUG
+
+if len(sys.argv) != 2:
+    raise Exception('Should pass version file as first argument')
+
+version = None
+version_fn = sys.argv[1]
+
+with open(version_fn) as version_file:
+    version = version_file.read().strip().split('.')
+
+if len(version) != 3:
+    raise Exception('Version file should contain \'major.minor.patch\'')
+
+logger.debug('Read version %s from version file %s', '.'.join(version), version_fn)
+# bump patch version
+version = '.'.join(*((major, minor, str(int(patch)+1)) for major, minor, patch in [version]))
+logger.debug('Writing back version %s into version file %s', version, version_fn)
+
+with open(version_fn, 'w') as version_file:
+    version_file.write(version)
+    version_file.write('\n')

--- a/ci/sync-version.py
+++ b/ci/sync-version.py
@@ -38,11 +38,11 @@ with open(version_fn) as version_file:
     version = version_file.read().strip().split('.')
 
 if len(version) != 3:
-    raise Exception('Version file should contain \'major.minor.patch\'')
+    raise Exception('Version file should be in the following format: \'x.y.z\'')
 
 logger.debug('Read version %s from version file %s', '.'.join(version), version_fn)
 # bump patch version
-version = '.'.join(*((major, minor, str(int(patch)+1)) for major, minor, patch in [version]))
+version = '.'.join(*((x, y, str(int(z) + 1)) for x, y, z in [version]))
 logger.debug('Writing back version %s into version file %s', version, version_fn)
 
 with open(version_fn, 'w') as version_file:


### PR DESCRIPTION
Fix #47 

This is a tool that helps incrementing version in version file across @graknlabs repos. Currently, only incrementing **patch** (following [semantic versioning](https://semver.org) terminology) version is supported.

Sample usage:

```
py_binary(
    name= "sync_version",
    srcs = ["@graknlabs_build_tools//ci:sync-version.py"],
    data= ["//:VERSION"],
    main = "ci/sync-version.py",
    args = ["$(location //:VERSION)"]
)
```

```
ghost:grakn vmax$ bazel run //:sync_version
INFO: Analyzed target //:sync_version (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //:sync_version up-to-date:
  bazel-bin/sync_version
INFO: Elapsed time: 0.200s, Critical Path: 0.01s
INFO: 0 processes.
INFO: Build completed successfully, 1 total action
INFO: Build completed successfully, 1 total action
[2019-05-10 12:56:50.316]: Read version 1.5.3 from version file ./VERSION
[2019-05-10 12:56:50.316]: Writing back version 1.5.4 into version file ./VERSION
```

```
diff --git a/VERSION b/VERSION
index 8af85beb5..94fe62c27 100644
--- a/VERSION
+++ b/VERSION
@@ -1 +1 @@
-1.5.3
+1.5.4
```