### PR TITLE
Implement SingleJar wrapper and include it in custom Java toolchain

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -16,6 +16,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+load("@bazel_tools//tools/jdk:default_java_toolchain.bzl", "default_java_toolchain")
+
+
 java_binary(
     name = "bazel-deps",
     main_class = "com.github.johnynek.bazel_deps.ParseProject",
@@ -30,4 +33,28 @@ sh_binary(
         "@unused_deps//file",
         "@unused_deps_osx//file",
     ],
+)
+
+# Toolchain that redefines singlejar to a version
+# that produces IntelliJ-compatible source JARs
+default_java_toolchain(
+    name = "java-toolchain",
+    source_version = "8",
+    target_version = "8",
+    singlejar = select({
+        "@bazel_tools//src/conditions:remote": ["@bazel_tools//src/tools/singlejar:singlejar"],
+        "//conditions:default": [":singlejar_deploy.jar"]
+    }),
+    visibility = ["//visibility:public"],
+)
+
+# Wrapper that remaps .java files to have correct
+# placement inside the source JAR
+java_binary(
+    name = "singlejar",
+    srcs = ["SingleJar.java"],
+    resources = [
+        "@bazel_tools//tools/jdk:singlejar/singlejar"
+    ],
+    main_class = "grakn.buildtools.SingleJar"
 )

--- a/bazel/SingleJar.java
+++ b/bazel/SingleJar.java
@@ -1,0 +1,100 @@
+package grakn.buildtools;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class SingleJar {
+    private final static Pattern JAVA_PACKAGE_PATTERN = Pattern.compile("package\\s+([\\w.]+);");
+    private final static String SINGLEJAR_EXECUTABLE = "/tools/jdk/singlejar/singlejar";
+
+    private static String javaPackage(String sourcePath) throws IOException {
+        for (String line: Files.readAllLines(Paths.get(sourcePath))) {
+            Matcher lineMatcher = JAVA_PACKAGE_PATTERN.matcher(line);
+            if (lineMatcher.find()) {
+                return lineMatcher.group(1);
+            }
+        }
+        return null;
+    }
+
+    private static String unpackSingleJar() throws IOException {
+        File singlejar = File.createTempFile("singlejar", "");
+        singlejar.deleteOnExit();
+
+        if (!singlejar.setExecutable(true)) {
+            throw new RuntimeException("Could not make singlejar executable");
+        }
+
+        int i;
+        byte[] buf = new byte[8192];
+
+        try (InputStream fileStream = SingleJar.class.getResourceAsStream(SINGLEJAR_EXECUTABLE);
+             OutputStream out = new FileOutputStream(singlejar)) {
+
+            while ((i = fileStream.read(buf)) != -1) {
+                out.write(buf, 0, i);
+            }
+        }
+
+        return singlejar.getAbsolutePath();
+    }
+
+    private static void patchSourceJarLinks(String[] args) throws IOException {
+        boolean inResources = false;
+        for (int i = 0; i < args.length; i++) {
+            String line = args[i];
+            if (line.equals("--resources")) {
+                inResources = true;
+                continue;
+            } else if (inResources && line.startsWith("--")) {
+                break;
+            }
+
+            if (inResources) {
+                String[] fl = line.split(":");
+                if (fl.length == 2) {
+                    String originalFn = fl[0];
+                    String archiveFn = fl[1];
+
+                    if (originalFn.endsWith(".java") && archiveFn.endsWith(".java")) {
+                        // we are sure to map source file to source file
+                        String resultingPath = javaPackage(originalFn).replaceAll("\\.", "/") + "/" + Paths.get(originalFn).getFileName().toString();
+                        args[i] = String.format("%s:%s", originalFn, resultingPath);
+                    }
+                }
+            }
+        }
+    }
+
+
+    public static void main(String[] args) throws IOException, InterruptedException {
+        for (String arg : args) {
+            if (arg.startsWith("@") && arg.endsWith(".params")) {
+                // @fn signifies that command-line arguments
+                // will be expanded from file with name 'fn'
+                Path fn = Paths.get(arg.replace("@", ""));
+                String[] lines = Files.readAllLines(fn).toArray(new String[0]);
+                patchSourceJarLinks(lines);
+                Files.write(fn, Arrays.asList(lines));
+                break;
+            }
+        }
+
+        List<String> singleJarWithArgs = new ArrayList<>(Arrays.asList(args));
+        singleJarWithArgs.add(0, unpackSingleJar());
+
+        Process process = new ProcessBuilder(singleJarWithArgs).inheritIO().start();
+        System.exit(process.waitFor());
+    }
+}


### PR DESCRIPTION
This is the first step to fixing graknlabs/grakn#4851

`singlejar` wrapper (`@graknlabs_build_tools//bazel:singlejar`) detects when `singlejar` is called to build a source JAR and modifies command-line arguments so that source file is placed with respect to `package` statement in it.

For class `com.smth.Main` *incorrect* (from IntellIJ”s standpoint) structure (and this is something that is currently produced) would be:
```
ghost:b vmax$ jar tf bazel-bin/main-src.jar
META-INF/
META-INF/MANIFEST.MF
Main.java
```

Correct source JAR (that would actually be picked up) would look like this:
```
ghost:b vmax$ jar tf bazel-bin/main-src.jar
META-INF/
META-INF/MANIFEST.MF
com/
com/lib/
com/lib/Main.java
```