### PR TITLE
Specify original version of singlejar for Windows builds

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -43,6 +43,7 @@ default_java_toolchain(
     target_version = "8",
     singlejar = select({
         "@bazel_tools//src/conditions:remote": ["@bazel_tools//src/tools/singlejar:singlejar"],
+        "@bazel_tools//src/conditions:windows": ["@bazel_tools//tools/jdk:singlejar/singlejar.exe"],
         "//conditions:default": [":singlejar_deploy.jar"]
     }),
     visibility = ["//visibility:public"],


### PR DESCRIPTION
## What is the goal of this PR?

Building Grakn Core on Windows was broken by a recent introduction of custom java toolchain in #51. This means that you weren't able to run `bazel build ...` on a Windows machine. As a consequence `test-assembly-windows-zip` is also broken. This pull request specifies correct version of `singlejar` to un-break the build.

Relevant error message:
```
ERROR: C:/users/circleci/_bazel_circleci/xuhrud3v/external/graknlabs_build_tools/bazel/BUILD:53:1: no such target '@bazel_tools//tools/jdk:singlejar/singlejar': target 'singlejar/singlejar' not declared in package 'tools/jdk' (did you mean 'singlejar/singlejar.exe'?) defined by C:/users/circleci/_bazel_circleci/xuhrud3v/external/bazel_tools/tools/jdk/BUILD and referenced by '@graknlabs_build_tools//bazel:singlejar'
```

## What are the changes implemented in this PR?

Specify the same version of `singlejar` for Windows build as used by default.