### PR TITLE
Install JDK for Mac CI builds

### DIFF
--- a/ci/install-bazel-mac.sh
+++ b/ci/install-bazel-mac.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
+brew cask install homebrew/cask-versions/adoptopenjdk8
 curl -OL https://github.com/bazelbuild/bazel/releases/download/0.25.2/bazel-0.25.2-installer-darwin-x86_64.sh
 chmod +x bazel-0.25.2-installer-darwin-x86_64.sh
 sudo ./bazel-0.25.2-installer-darwin-x86_64.sh


### PR DESCRIPTION
Latest XCode image for CircleCI (`10.1`) does not have installed JDK, which prevents `bazel` to build code (relevant issue: https://github.com/bazelbuild/bazel/issues/7304). This PR adds installing `AdoptOpenJDK8` via Homebrew, un-breaking the build.