### PR TITLE
Adapt to newest singlejar placement in bazel v0.26.0

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -42,8 +42,8 @@ default_java_toolchain(
     source_version = "8",
     target_version = "8",
     singlejar = select({
-        "@bazel_tools//src/conditions:remote": ["@bazel_tools//src/tools/singlejar:singlejar"],
-        "@bazel_tools//src/conditions:windows": ["@bazel_tools//tools/jdk:singlejar/singlejar.exe"],
+        "@bazel_tools//src/conditions:remote": ["@remote_java_tools_linux//:SingleJar"],
+        "@bazel_tools//src/conditions:windows": ["@remote_java_tools_windows//:SingleJar"],
         "//conditions:default": [":singlejar_deploy.jar"]
     }),
     visibility = ["//visibility:public"],
@@ -55,7 +55,7 @@ java_binary(
     name = "singlejar",
     srcs = ["SingleJar.java"],
     resources = [
-        "@bazel_tools//tools/jdk:singlejar/singlejar"
+        "@bazel_tools//tools/jdk:singlejar"
     ],
     main_class = "grakn.buildtools.SingleJar"
 )

--- a/bazel/SingleJar.java
+++ b/bazel/SingleJar.java
@@ -16,7 +16,10 @@ import java.util.regex.Pattern;
 
 public class SingleJar {
     private final static Pattern JAVA_PACKAGE_PATTERN = Pattern.compile("package\\s+([\\w.]+);");
-    private final static String SINGLEJAR_EXECUTABLE = "/tools/jdk/singlejar/singlejar";
+    // bazel v0.25.2 and before
+    private final static String SINGLEJAR_EXECUTABLE_OLD = "/tools/jdk/singlejar/singlejar";
+    // bazel v0.26.0 and onwards
+    private final static String SINGLEJAR_EXECUTABLE = "/tools/singlejar/singlejar_local";
 
     private static String javaPackage(String sourcePath) throws IOException {
         for (String line: Files.readAllLines(Paths.get(sourcePath))) {
@@ -39,7 +42,16 @@ public class SingleJar {
         int i;
         byte[] buf = new byte[8192];
 
-        try (InputStream fileStream = SingleJar.class.getResourceAsStream(SINGLEJAR_EXECUTABLE);
+        InputStream is;
+        is = SingleJar.class.getResourceAsStream(SINGLEJAR_EXECUTABLE_OLD);
+        if (is == null) {
+            is = SingleJar.class.getResourceAsStream(SINGLEJAR_EXECUTABLE);
+        }
+        if (is == null) {
+            throw new RuntimeException("Could not find singlejar executable in JAR");
+        }
+
+        try (InputStream fileStream = is;
              OutputStream out = new FileOutputStream(singlejar)) {
 
             while ((i = fileStream.read(buf)) != -1) {


### PR DESCRIPTION
Build failed on `bazel` `v0.26.0` with the following error:

```
ERROR: /private/var/tmp/_bazel_enricoboccadifuoco/3aac2f4ba9b1e5eaf21b07e0e0d63f02/external/graknlabs_build_tools/bazel/BUILD:54:1: no such target '@bazel_tools//tools/jdk:singlejar/singlejar': target 'singlejar/singlejar' not declared in package 'tools/jdk' defined by /private/var/tmp/_bazel_enricoboccadifuoco/3aac2f4ba9b1e5eaf21b07e0e0d63f02/external/bazel_tools/tools/jdk/BUILD and referenced by '@graknlabs_build_tools//bazel:singlejar'
```

This pull request introduces `singlejar` definition compatible with both `v0.25.2` which is currently used by us and `v0.26.0` which is the next version.