### PR TITLE
Use same singlejar binary on all platforms

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -41,11 +41,7 @@ default_java_toolchain(
     name = "java-toolchain",
     source_version = "8",
     target_version = "8",
-    singlejar = select({
-        "@bazel_tools//src/conditions:remote": ["@remote_java_tools_linux//:SingleJar"],
-        "@bazel_tools//src/conditions:windows": ["@remote_java_tools_windows//:SingleJar"],
-        "//conditions:default": [":singlejar_deploy.jar"]
-    }),
+    singlejar = [":singlejar_deploy.jar"],
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
In order to support building Grakn on all platforms on both `v0.25.2` and `v0.26.0` of `bazel`, same `singlejar` should be used. This PR brings support for `.exe` versions of `singlejar` for Windows into our custom `singlejar` and unifies the source jar building process on all platforms.