### PR TITLE
run-bazel-rbe should account for platform it is running on

### DIFF
--- a/ci/run-bazel-rbe.py
+++ b/ci/run-bazel-rbe.py
@@ -19,6 +19,7 @@
 #
 
 import os
+import platform
 import sys
 import subprocess as sp
 
@@ -36,8 +37,9 @@ def add_rbe_param(cmd):
 
 
 command = ' '.join(sys.argv[1:])
+is_linux = platform.system() == 'Linux'
 
-if os.path.isfile(os.path.expanduser('~/.config/gcloud/application_default_credentials.json')):
+if is_linux and os.path.isfile(os.path.expanduser('~/.config/gcloud/application_default_credentials.json')):
     print('Bazel will be executed with RBE support. '
           'This means the build is remotely executed '
           'and the cache will be re-used by subsequent CI jobs.')


### PR DESCRIPTION
To fix #326, `//ci:run-bazel-rbe` will be utilized. However, RBE does not support building for Mac, failing with the following error:
```
ERROR: /private/var/tmp/_bazel_vmax/d2feb27241ea51489aa2f0591c0e06e6/external/bazel_toolchains/configs/ubuntu16_04_clang/9.0.0/bazel_0.25.2/cc/BUILD:45:1: in cc_toolchain_suite rule @bazel_toolchains//configs/ubuntu16_04_clang/9.0.0/bazel_0.25.2/cc:toolchain: cc_toolchain_suite '@bazel_toolchains//configs/ubuntu16_04_clang/9.0.0/bazel_0.25.2/cc:toolchain' does not contain a toolchain for cpu 'darwin'
```

Therefore, RBE builds on non-Linux systems will be ignored even if gcloud config file is present.
