### PR TITLE
checkstyle_test: support Grakn KGMS proprietary license header

### DIFF
--- a/checkstyle/config/BUILD
+++ b/checkstyle/config/BUILD
@@ -8,6 +8,7 @@ filegroup(
     srcs = [
         "checkstyle-file-header-agpl.txt",
         "checkstyle-file-header-apache.txt",
+        "checkstyle-file-header-grakn-kgms.txt",
     ],
     visibility = ["//visibility:public"]
 )

--- a/checkstyle/config/checkstyle-file-header-grakn-kgms.txt
+++ b/checkstyle/config/checkstyle-file-header-grakn-kgms.txt
@@ -1,0 +1,10 @@
+^\W*
+^\W*Copyright \(c\) Grakn Labs, 2019$
+^\W*$
+^\W*This unpublished material is proprietary to Grakn Labs.$
+^\W*All rights reserved. The methods and$
+^\W*techniques described herein are considered trade secrets$
+^\W*and/or confidential. Reproduction or distribution, in whole$
+^\W*or in part, is forbidden except by express written permission$
+^\W*of Grakn Labs.$
+^\W*$

--- a/checkstyle/rules.bzl
+++ b/checkstyle/rules.bzl
@@ -53,6 +53,8 @@ def _checkstyle_test_impl(ctx):
 
     if ctx.attr.license_type == "apache":
         license_file = "external/graknlabs_build_tools/checkstyle/config/checkstyle-file-header-apache.txt"
+    elif ctx.attr.license_type == "grakn-kgms":
+        license_file = "external/graknlabs_build_tools/checkstyle/config/checkstyle-file-header-grakn-kgms.txt"
     else:
         license_file = "external/graknlabs_build_tools/checkstyle/config/checkstyle-file-header-agpl.txt"
 
@@ -115,7 +117,7 @@ checkstyle_test = rule(
     attrs = {
         "license_type": attr.string(
             doc = "Type of license to produce the header for every source code",
-            values = ["agpl", "apache"],
+            values = ["agpl", "apache", "grakn-kgms"],
             default = "agpl",
         ),
         "properties": attr.label(


### PR DESCRIPTION
In order to use `checkstyle_test` with Grakn KGMS codebase, it should support KGMS's license header:

```
/*
 * Copyright (c) Grakn Labs, 2019
 *
 * This unpublished material is proprietary to Grakn Labs.
 * All rights reserved. The methods and
 * techniques described herein are considered trade secrets
 * and/or confidential. Reproduction or distribution, in whole
 * or in part, is forbidden except by express written permission
 * of Grakn Labs.
 */
```