### PR TITLE
Fixing some unknown changes in `bazel` which prevented us from deploying Maven artifacts

### DIFF
--- a/bazel/SingleJar.java
+++ b/bazel/SingleJar.java
@@ -101,21 +101,25 @@ public class SingleJar {
 
 
     public static void main(String[] args) throws IOException, InterruptedException {
+        List<String> singleJarWithArgs = new ArrayList<>(args.length);
+
         for (String arg : args) {
+            String newArg = arg;
             if (arg.startsWith("@") && arg.endsWith(".params")) {
                 // @fn signifies that command-line arguments
                 // will be expanded from file with name 'fn'
                 Path fn = Paths.get(arg.replace("@", ""));
                 String[] lines = Files.readAllLines(fn).toArray(new String[0]);
                 patchSourceJarLinks(lines);
-                Files.write(fn, Arrays.asList(lines));
-                break;
+
+                File paramsFile = File.createTempFile("patched.params", "");
+                Files.write(paramsFile.toPath(), Arrays.asList(lines));
+                newArg = "@" + paramsFile.toPath().toString();
             }
+            singleJarWithArgs.add(newArg);
         }
 
-        List<String> singleJarWithArgs = new ArrayList<>(Arrays.asList(args));
         singleJarWithArgs.add(0, unpackSingleJar());
-
         Process process = new ProcessBuilder(singleJarWithArgs).inheritIO().start();
         System.exit(process.waitFor());
     }


### PR DESCRIPTION
## What is the goal of this PR?

Fixing some unknown changes in `bazel` which prevented us from deploying Maven artifacts due to file permission issue (`java.nio.file.FileSystemException: bazel-out/k8-fastbuild/bin/api/libapi-src.jar-0.params: Read-only file system`).

## What are the changes implemented in this PR?

Previously, `.params` file [produced by `bazel`] was rewritten in-place. This PR writes contents of it to a separate temporary file and modifies argument to reference it instead.

