### PR TITLE
Sync rules with latest @graknlabs_bazel_distribution

### DIFF
--- a/distribution/maven/BUILD
+++ b/distribution/maven/BUILD
@@ -22,8 +22,8 @@ genrule(
         "@graknlabs_bazel_distribution//maven/templates:rules.bzl",
         "@graknlabs_build_tools//:deployment.properties"
     ],
-    tools = ["@graknlabs_bazel_distribution//maven:deployment_rules_builder.py"],
-    cmd = "$(location @graknlabs_bazel_distribution//maven:deployment_rules_builder.py) " +
+    tools = ["@graknlabs_bazel_distribution//maven:deployment_rules_builder"],
+    cmd = "$(location @graknlabs_bazel_distribution//maven:deployment_rules_builder) " +
         "$(location @graknlabs_bazel_distribution//maven/templates:rules.bzl) $@ " +
         "$(location @graknlabs_build_tools//:deployment.properties) " +
         "@graknlabs_build_tools//:deployment.properties",

--- a/distribution/maven/rules.bzl
+++ b/distribution/maven/rules.bzl
@@ -274,35 +274,46 @@ assemble_maven = rule(
             aspects = [
                 _java_lib_deps,
                 _maven_pom_deps,
-            ]
+            ],
+            doc = "Java target for subsequent deployment"
         ),
-        "package": attr.string(),
+        "package": attr.string(
+            doc = "Bazel package of this target. Must match one defined in `_maven_packages`"
+        ),
         "version_file": attr.label(
             mandatory = True,
             allow_single_file = True,
+            doc = "File containing version string"
         ),
         "workspace_refs": attr.label(
             mandatory = True,
             allow_single_file = True,
+            doc = 'JSON file describing dependencies to other Bazel workspaces'
         ),
         "project_name": attr.string(
-            default = "PROJECT_NAME"
+            default = "PROJECT_NAME",
+            doc = 'Project name to fill into pom.xml'
         ),
         "project_description": attr.string(
-            default = "PROJECT_DESCRIPTION"
+            default = "PROJECT_DESCRIPTION",
+            doc = 'Project description to fill into pom.xml'
         ),
         "project_url": attr.string(
-            default = "PROJECT_URL"
+            default = "PROJECT_URL",
+            doc = 'Project URL to fill into pom.xml'
         ),
         "license": attr.string(
             values=["apache"],
-            default = "apache"
+            default = "apache",
+            doc = 'Project license to fill into pom.xml'
         ),
         "scm_url": attr.string(
-            default = "PROJECT_URL"
+            default = "PROJECT_URL",
+            doc = 'Project source control URL to fill into pom.xml'
         ),
         "developers": attr.string_list_dict(
-            default = {}
+            default = {},
+            doc = 'Project developers to fill into pom.xml'
         ),
         "_pom_xml_template": attr.label(
             allow_single_file = True,
@@ -319,6 +330,7 @@ assemble_maven = rule(
         )
     },
     implementation = _assemble_maven_impl,
+    doc = "Assemble Java package for subsequent deployment to Maven repo"
 )
 
 
@@ -349,12 +361,14 @@ def _deploy_maven_impl(ctx):
             ctx.attr.target[MavenDeploymentInfo].jar,
             ctx.attr.target[MavenDeploymentInfo].pom,
             ctx.attr.target[MavenDeploymentInfo].srcjar,
-            ctx.file.deployment_properties
+            ctx.file.deployment_properties,
+            ctx.file._common_py
         ], symlinks = {
             lib_jar_link: ctx.attr.target[MavenDeploymentInfo].jar,
             pom_xml_link: ctx.attr.target[MavenDeploymentInfo].pom,
             src_jar_link: ctx.attr.target[MavenDeploymentInfo].jar,
             'deployment.properties': ctx.file.deployment_properties,
+            "common.py": ctx.file._common_py
         })
     )
 
@@ -362,18 +376,25 @@ _default_deployment_properties = None if 'deployment_properties_placeholder' in 
 deploy_maven = rule(
     attrs = {
         "target": attr.label(
-            providers = [MavenDeploymentInfo]
+            providers = [MavenDeploymentInfo],
+            doc = "assemble_maven target to deploy"
         ),
         "deployment_properties": attr.label(
             allow_single_file = True,
             mandatory = not bool(_default_deployment_properties),
-            default = _default_deployment_properties
+            default = _default_deployment_properties,
+            doc = 'Properties file containing repo.maven.(snapshot|release) key'
         ),
         "_deployment_script": attr.label(
             allow_single_file = True,
             default = "@graknlabs_bazel_distribution//maven/templates:deploy.py",
         ),
+        "_common_py": attr.label(
+            allow_single_file = True,
+            default = "@graknlabs_bazel_distribution//common:common.py",
+        )
     },
     executable = True,
-    implementation = _deploy_maven_impl
+    implementation = _deploy_maven_impl,
+    doc = "Deploy `assemble_maven` target into Maven repo"
 )


### PR DESCRIPTION
- Use `@graknlabs_bazel_distribution//maven:deployment_rules_builder` (proper `py_binary` target) instead of `@graknlabs_bazel_distribution//maven:deployment_rules_builder.py` (exported Python script): introduced in graknlabs/bazel-distribution#143
- Run `distribution/maven/update.sh` to sync `rules.bzl`