### PR TITLE
Sync Maven rules with latest @graknlabs_bazel_distribution

### DIFF
--- a/distribution/maven/rules.bzl
+++ b/distribution/maven/rules.bzl
@@ -366,7 +366,7 @@ def _deploy_maven_impl(ctx):
         ], symlinks = {
             lib_jar_link: ctx.attr.target[MavenDeploymentInfo].jar,
             pom_xml_link: ctx.attr.target[MavenDeploymentInfo].pom,
-            src_jar_link: ctx.attr.target[MavenDeploymentInfo].jar,
+            src_jar_link: ctx.attr.target[MavenDeploymentInfo].srcjar,
             'deployment.properties': ctx.file.deployment_properties,
             "common.py": ctx.file._common_py
         })


### PR DESCRIPTION
- Run `distribution/maven/update.sh` to sync `rules.bzl` so that graknlabs/bazel-distribution#145 is included