### PR TITLE
Update bazel-deps

### DIFF
--- a/bazel/dependencies.bzl
+++ b/bazel/dependencies.bzl
@@ -39,8 +39,7 @@ def bazel_toolchain():
 def bazel_deps():
     http_jar(
         name = "bazel_deps",
-        sha256 = "43278a0042e253384543c4700021504019c1f51f3673907a1b25bb1045461c0c",
-        urls = ["https://github.com/graknlabs/bazel-deps/releases/download/v0.2/grakn-bazel-deps-v0.2.jar"],
+        urls = ["https://github.com/lolski/bazel-deps/releases/download/0.3/parseproject_deploy.jar"],
     )
 
 def bazel_rules_docker():

--- a/bazel/dependencies.bzl
+++ b/bazel/dependencies.bzl
@@ -39,7 +39,6 @@ def bazel_toolchain():
 def bazel_deps():
     http_jar(
         name = "bazel_deps",
-        executable = True,
         urls = ["https://github.com/graknlabs/bazel-deps/releases/download/0.3/grakn-bazel-deps-0.3.jar"],
     )
 

--- a/bazel/dependencies.bzl
+++ b/bazel/dependencies.bzl
@@ -39,7 +39,8 @@ def bazel_toolchain():
 def bazel_deps():
     http_jar(
         name = "bazel_deps",
-        urls = ["https://github.com/lolski/bazel-deps/releases/download/0.3/parseproject_deploy.jar"],
+        executable = True,
+        urls = ["https://github.com/graknlabs/bazel-deps/releases/download/0.3/grakn-bazel-deps-0.3.jar"],
     )
 
 def bazel_rules_docker():


### PR DESCRIPTION
Build tool now contains an updated `bazel-deps` in which the most relevant change is the ability to properly recompute Maven dependency checksum which got reuploaded.