### PR TITLE
Upgrade @stackb_rules_proto to fix bazel incompatibility

### DIFF
--- a/grpc/dependencies.bzl
+++ b/grpc/dependencies.bzl
@@ -27,5 +27,5 @@ def grpc_dependencies():
     git_repository(
         name = "stackb_rules_proto",
         remote = "https://github.com/stackb/rules_proto",
-        commit = "137014a36f389cfcb4987a567b7bd23a7a259cf9",
+        commit = "e783457abea020e7df6b94acb54f668c0473ae31",
     )


### PR DESCRIPTION
In order to use `python_grpc_library`, we need to bump version of `@stackb_rules_proto` to include https://github.com/stackb/rules_proto/commit/e783457abea020e7df6b94acb54f668c0473ae31. Otherwise, supplying `--incompatible_disallow_dict_plus` to every `bazel` invocation would be required.