### PR TITLE
Revert to upstream rules_nodejs

### DIFF
--- a/bazel/dependencies.bzl
+++ b/bazel/dependencies.bzl
@@ -51,10 +51,10 @@ def bazel_rules_docker():
     )
 
 def bazel_rules_nodejs():
-    git_repository(
+    http_archive(
         name = "build_bazel_rules_nodejs",
-        remote = "https://github.com/graknlabs/rules_nodejs.git",
-        commit = "ae55e5b839aad78dd12a11ea4fe9601664c40a96",
+        sha256 = "3b0116a8a91a75678a57ba676c246ac0fa9c90dc3d46daef305b11b54ed4467e",
+        urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.33.1/rules_nodejs-0.33.1.tar.gz"],
     )
 
 def bazel_rules_python():


### PR DESCRIPTION
Since `graknlabs/rules_nodejs` is going to be deprecated, we're reverting to most-recent version of `@build_bazel_rules_nodejs`