### PR TITLE
Upgrade bazel to 0.26.1

### DIFF
--- a/ci/install-bazel-linux.sh
+++ b/ci/install-bazel-linux.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
-curl -OL https://github.com/bazelbuild/bazel/releases/download/0.25.2/bazel-0.25.2-installer-linux-x86_64.sh
-chmod +x bazel-0.25.2-installer-linux-x86_64.sh
-sudo ./bazel-0.25.2-installer-linux-x86_64.sh
-rm ./bazel-0.25.2-installer-linux-x86_64.sh
+curl -OL https://github.com/bazelbuild/bazel/releases/download/0.26.1/bazel-0.26.1-installer-linux-x86_64.sh
+chmod +x bazel-0.26.1-installer-linux-x86_64.sh
+sudo ./bazel-0.26.1-installer-linux-x86_64.sh
+rm ./bazel-0.26.1-installer-linux-x86_64.sh

--- a/ci/install-bazel-mac.sh
+++ b/ci/install-bazel-mac.sh
@@ -2,7 +2,7 @@
 
 set -e
 brew cask install homebrew/cask-versions/adoptopenjdk8
-curl -OL https://github.com/bazelbuild/bazel/releases/download/0.25.2/bazel-0.25.2-installer-darwin-x86_64.sh
-chmod +x bazel-0.25.2-installer-darwin-x86_64.sh
-sudo ./bazel-0.25.2-installer-darwin-x86_64.sh
-rm ./bazel-0.25.2-installer-darwin-x86_64.sh
+curl -OL https://github.com/bazelbuild/bazel/releases/download/0.26.1/bazel-0.26.1-installer-darwin-x86_64.sh
+chmod +x bazel-0.26.1-installer-darwin-x86_64.sh
+sudo ./bazel-0.26.1-installer-darwin-x86_64.sh
+rm ./bazel-0.26.1-installer-darwin-x86_64.sh


### PR DESCRIPTION
Upgraded `rules-nodejs` require `bazel 0.26.0` as minimal supported version. Due to us not being able to use `0.27.0` and further versions (rel issue: bazelbuild/bazel#8659), we're using `0.26.1`