### PR TITLE
Make sure builds executed locally don't fail

### DIFF
--- a/ci/install-bazel-rbe.sh
+++ b/ci/install-bazel-rbe.sh
@@ -15,6 +15,8 @@ function install_dependencies() {
     fi
 }
 
+install_dependencies
+
 echo "Installing RBE credential..."
 if [[ -n "$BAZEL_RBE_CREDENTIAL" ]]; then
     BAZEL_RBE_CREDENTIAL_LOCATION=~/.config/gcloud/application_default_credentials.json
@@ -24,5 +26,4 @@ if [[ -n "$BAZEL_RBE_CREDENTIAL" ]]; then
     echo "The RBE credential has been installed!"
 else
     echo "No RBE credential found. Bazel will be executed locally without RBE support."
-    install_dependencies
 fi

--- a/ci/install-bazel-rbe.sh
+++ b/ci/install-bazel-rbe.sh
@@ -1,6 +1,20 @@
 #!/bin/bash
 
 set -e
+
+function install_rpmbuild() {
+    echo "Installing rpmbuild..."
+    if [[ "$OSTYPE" == "linux-gnu" ]]; then
+        sudo apt-get update
+        sudo apt-get install rpm
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        brew install rpm
+    else
+        echo "Your platform does not have rpmbuild executable for it. Make sure you are using Linux/macOS".
+        exit 1
+    fi
+}
+
 echo "Installing RBE credential..."
 if [[ -n "$BAZEL_RBE_CREDENTIAL" ]]; then
     BAZEL_RBE_CREDENTIAL_LOCATION=~/.config/gcloud/application_default_credentials.json
@@ -10,4 +24,5 @@ if [[ -n "$BAZEL_RBE_CREDENTIAL" ]]; then
     echo "The RBE credential has been installed!"
 else
     echo "No RBE credential found. Bazel will be executed locally without RBE support."
+    install_rpmbuild
 fi

--- a/ci/install-bazel-rbe.sh
+++ b/ci/install-bazel-rbe.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-function install_rpmbuild() {
+function install_dependencies() {
     echo "Installing rpmbuild..."
     if [[ "$OSTYPE" == "linux-gnu" ]]; then
         sudo apt-get update
@@ -24,5 +24,5 @@ if [[ -n "$BAZEL_RBE_CREDENTIAL" ]]; then
     echo "The RBE credential has been installed!"
 else
     echo "No RBE credential found. Bazel will be executed locally without RBE support."
-    install_rpmbuild
+    install_dependencies
 fi


### PR DESCRIPTION
Fixes #77 
The logic is as follows:
- if build is *not* an RBE build:
  - if platform is Linux:
    - `apt-get install rpm`
  - if platform is Darwin:
    - `brew install rpm`
  - else
    - fail