### PR TITLE
KGLIB sync dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
           graql:master grakn:master grakn-kgms:master protocol:master \
           client-java:master client-python:master client-nodejs:master \
           benchmark:master biograkn:master workbase:master \
-          docs:master examples:master
+          docs:master examples:master kglib:master
 
 workflows:
   build-tools:


### PR DESCRIPTION
## What is the goal of this PR?

We update CI to automatically update `graknlabs/kglib` such that it always depends upon the latest commit of `graknlabs/build-tools`

## What are the changes implemented in this PR?

- Updates the targets of sync-dependencies jobs