### PR TITLE
Add apt-wait.sh, which waits for an existing apt process to finish

### DIFF
--- a/ci/BUILD
+++ b/ci/BUILD
@@ -76,3 +76,8 @@ py_binary(
     srcs = ["test-cache.py"],
     main = "test-cache.py"
 )
+
+sh_binary(
+    name = "apt-wait",
+    srcs = ["apt-wait.sh"],
+)

--- a/ci/BUILD
+++ b/ci/BUILD
@@ -76,8 +76,3 @@ py_binary(
     srcs = ["test-cache.py"],
     main = "test-cache.py"
 )
-
-sh_binary(
-    name = "apt-wait",
-    srcs = ["apt-wait.sh"],
-)

--- a/ci/apt-wait.sh
+++ b/ci/apt-wait.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo 'Waiting for the initial apt-get process to finish...'
+echo -n 'Waiting for the initial apt-get process to finish...'
 init_wait=0
 while [[ $init_wait -eq 0 ]]; do
   set +e

--- a/ci/apt-wait.sh
+++ b/ci/apt-wait.sh
@@ -4,7 +4,7 @@ echo -n 'Waiting for the initial apt-get process to finish...'
 init_wait=0
 while [[ $init_wait -eq 0 ]]; do
   set +e
-  ps -C apt-get
+  ps -C apt-get > /dev/null
   init_wait=$?
   set -e
   echo -n '.'

--- a/ci/apt-wait.sh
+++ b/ci/apt-wait.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+echo -n 'Waiting for the initial apt-get process to finish...'
+init_wait=0
+while [[ $init_wait -eq 0 ]]; do
+  set +e
+  ps -C apt-get
+  init_wait=$?
+  set -e
+  echo -n '.'
+  sleep 1
+done
+echo 'done.'

--- a/ci/apt-wait.sh
+++ b/ci/apt-wait.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo -n 'Waiting for the initial apt-get process to finish...'
+echo 'Waiting for the initial apt-get process to finish...'
 init_wait=0
 while [[ $init_wait -eq 0 ]]; do
   set +e


### PR DESCRIPTION
Sometimes, our CI job which installs dependencies using `apt` would fail because the machine may perform an initial `apt` update in the background. This PR adds `apt-wait.sh` for waiting for an existing `apt` to finish.