### PR TITLE
Make release-approval script Python 2/3 compatible

### DIFF
--- a/ci/release-approval.py
+++ b/ci/release-approval.py
@@ -38,7 +38,7 @@ grabl_data = {
 grabl_url_new = '{GRABL_HOST}/release/new'.format(GRABL_HOST=GRABL_HOST)
 grabl_url_status = '{GRABL_HOST}/release/{commit}/status'.format(GRABL_HOST=GRABL_HOST, commit=workflow_id)
 
-new_release_signature = hmac.new(git_token, json.dumps(grabl_data), hashlib.sha1).hexdigest()
+new_release_signature = hmac.new(git_token.encode(), json.dumps(grabl_data).encode(), hashlib.sha1).hexdigest()
 print("Tests have been ran and everything is in a good, releasable state. "
     "It is possible to proceed with the release process. Waiting for approval.")
 common.shell_execute([

--- a/ci/release-approval.py
+++ b/ci/release-approval.py
@@ -48,7 +48,7 @@ common.shell_execute([
 status = 'no-status'
 
 while status == 'no-status':
-    get_release_status_signature = hmac.new(git_token, '', hashlib.sha1).hexdigest()
+    get_release_status_signature = hmac.new(git_token.encode(), ''.encode(), hashlib.sha1).hexdigest()
     status, _ = common.shell_execute(['curl', '--silent', '--show-error', '--fail', '-H', 'X-Hub-Signature: ' + get_release_status_signature, grabl_url_status])
 
     if status == 'deploy':


### PR DESCRIPTION
Fixes #85 
Apparently, `hmac.new` now only accepts encoded `bytes` (as opposed to `str` in Python 2). Calling `.encode()` on first two arguments is supported in both Python versions.