### PR TITLE
Allow release notes to contain UTF8 chars

### DIFF
--- a/ci/release-notes.py
+++ b/ci/release-notes.py
@@ -4,6 +4,7 @@ import github
 import os
 import re
 import sys
+from io import open
 
 GITHUB_TOKEN = os.getenv('RELEASE_NOTES_TOKEN')
 if GITHUB_TOKEN is None:
@@ -106,7 +107,7 @@ if __name__ == '__main__':
 
     release_notes_content = re.sub(release_notes_template_regex, release_notes, release_notes_content, 1, flags=re.IGNORECASE)
 
-    with open(release_template_filepath, 'w') as filepath:
+    with open(release_template_filepath, 'w', encoding='utf-8') as filepath:
         filepath.write(release_notes_content)
 
     release_milestone.edit(release_milestone.title, state="closed")


### PR DESCRIPTION
[This run of CI](https://circleci.com/gh/graknlabs/protocol/238) failed since some PRs contained non-ASCII chars and therefore failed with the following stacktrace:
```
Traceback (most recent call last):
  File "/home/circleci/.cache/bazel/_bazel_circleci/9f69b2e90a3e4f79cd001380bef9d42c/execroot/graknlabs_protocol/bazel-out/k8-fastbuild/bin/external/graknlabs_build_tools/ci/release-notes.runfiles/graknlabs_build_tools/ci/release-notes.py", line 110, in <module>
    filepath.write(release_notes_content)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 1267-1268: ordinal not in range(128)
```

This PR opens the output file with correct encoding so this error can be avoided.