### PR TITLE
Add certifi as a dependency of //ci:release-notes

### DIFF
--- a/ci/BUILD
+++ b/ci/BUILD
@@ -57,6 +57,7 @@ py_binary(
         requirement("chardet"),
         requirement("idna"),
         requirement("wrapt"),
+        requirement("certifi"),
     ]
 )
 


### PR DESCRIPTION
Fix #74 
`certifi` is now included to `deps` of `release-notes`