### PR TITLE
Install rpmbuild conditionally

### DIFF
--- a/ci/install-bazel-rbe.sh
+++ b/ci/install-bazel-rbe.sh
@@ -15,10 +15,8 @@ function install_dependencies() {
     fi
 }
 
-install_dependencies
-
-echo "Installing RBE credential..."
 if [[ -n "$BAZEL_RBE_CREDENTIAL" ]]; then
+    echo "Installing RBE credential..."
     BAZEL_RBE_CREDENTIAL_LOCATION=~/.config/gcloud/application_default_credentials.json
     echo "An RBE credential is found and will be saved to $BAZEL_RBE_CREDENTIAL_LOCATION. Bazel will be executed with RBE support."
     mkdir -p ~/.config/gcloud/
@@ -26,4 +24,5 @@ if [[ -n "$BAZEL_RBE_CREDENTIAL" ]]; then
     echo "The RBE credential has been installed!"
 else
     echo "No RBE credential found. Bazel will be executed locally without RBE support."
+    install_dependencies
 fi


### PR DESCRIPTION
To increase build time and not install `rpmbuild` which is not needed is build is executed remotely