### PR TITLE
Modify how we visually indicate for input

### DIFF
--- a/ci/release-approval.py
+++ b/ci/release-approval.py
@@ -71,6 +71,6 @@ while status == 'no-status':
         break
 
     # print '...' to provide a visual indication that it's waiting for an input
-    sys.stdout.write('.')
+    sys.stdout.write('...\n')
     sys.stdout.flush()
-    time.sleep(1)
+    time.sleep(60)


### PR DESCRIPTION
For proper output on CircleCI, we now print `...` and a newline every minute rather than `.` every second