### PR TITLE
Implement //ci:release-validate-deps

### DIFF
--- a/ci/BUILD
+++ b/ci/BUILD
@@ -61,6 +61,12 @@ py_binary(
     ]
 )
 
+py_binary(
+    name = "release-validate-deps",
+    srcs = ["release-validate-deps.py"],
+    main = "release-validate-deps.py",
+)
+
 sh_binary(
     name = "install-bazel-rbe",
     srcs = ["install-bazel-rbe.sh"]

--- a/ci/release-validate-deps.py
+++ b/ci/release-validate-deps.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+if __name__ == '__main__':
+    dependencies_bzl = os.path.join('dependencies', 'graknlabs', 'dependencies.bzl')
+    snapshot_dependencies = []
+    with open(os.path.join(os.getenv("BUILD_WORKSPACE_DIRECTORY"), dependencies_bzl)) as dependencies_bzl_:
+        dependencies_bzl__ = dependencies_bzl_.read().splitlines()
+        for arg in sys.argv[1:]:
+            dependency = filter(lambda line: line.endswith('@' + arg), dependencies_bzl__)
+            if len(dependency) == 1:
+                depend_by_tag = dependency[0].strip().startswith('tag')
+                if not depend_by_tag:
+                    snapshot_dependencies.append(arg)
+            else:
+                raise RuntimeError('Invalid sync-marker found for {}. '
+                                   'There is supposed to be exactly one sync-marker '
+                                   'but {} occurrences found.'.format(arg, len(dependency)))
+    if len(snapshot_dependencies) == 0:
+        print('This repository is releasable because the dependencies are '
+              'all release dependencies: {}'.format(sys.argv[1:]))
+    else:
+        raise RuntimeError('Error: This commit is not releasable because '
+                           'there are one or more snapshot dependencies: {}. '
+                           'Check that every dependencies listed in {} are all release dependencies '
+                           '(ie., depends on a tag instead of a commit)'
+                           .format(snapshot_dependencies, dependencies_bzl))

--- a/ci/release-validate-deps.py
+++ b/ci/release-validate-deps.py
@@ -17,11 +17,11 @@ if __name__ == '__main__':
                                    'There is supposed to be exactly one sync-marker '
                                    'but {} occurrences found.'.format(arg, len(dependency)))
     if len(snapshot_dependencies) == 0:
-        print('This repository is releasable because the dependencies are '
-              'all release dependencies: {}'.format(sys.argv[1:]))
+        print('This commit is releasable because the dependencies are '
+              'all released dependencies: {}'.format(sys.argv[1:]))
     else:
         raise RuntimeError('This commit is not releasable because '
                            'there are one or more snapshot dependencies: {}. '
-                           'Check that every dependencies listed in {} are all release dependencies '
+                           'Check that every dependencies listed in {} are all released dependencies '
                            '(ie., depends on a tag instead of a commit).'
                            .format(snapshot_dependencies, dependencies_bzl))

--- a/ci/release-validate-deps.py
+++ b/ci/release-validate-deps.py
@@ -2,12 +2,12 @@ import os
 import sys
 
 if __name__ == '__main__':
-    dependencies_bzl = os.path.join('dependencies', 'graknlabs', 'dependencies.bzl')
+    deps_path = os.path.join('dependencies', 'graknlabs', 'dependencies.bzl')
     snapshot_dependencies = []
-    with open(os.path.join(os.getenv("BUILD_WORKSPACE_DIRECTORY"), dependencies_bzl)) as dependencies_bzl_:
-        dependencies_bzl__ = dependencies_bzl_.read().splitlines()
+    with open(os.path.join(os.getenv("BUILD_WORKSPACE_DIRECTORY"), deps_path)) as deps_file_object:
+        deps_content = deps_file_object.read().splitlines()
         for arg in sys.argv[1:]:
-            dependency = filter(lambda line: line.endswith('@' + arg), dependencies_bzl__)
+            dependency = list(filter(lambda line: line.endswith('@' + arg), deps_content))
             if len(dependency) == 1:
                 depend_by_tag = dependency[0].strip().startswith('tag')
                 if not depend_by_tag:
@@ -24,4 +24,4 @@ if __name__ == '__main__':
                            'there are one or more snapshot dependencies: {}. '
                            'Check that every dependencies listed in {} are all released dependencies '
                            '(ie., depends on a tag instead of a commit).'
-                           .format(snapshot_dependencies, dependencies_bzl))
+                           .format(snapshot_dependencies, deps_path))

--- a/ci/release-validate-deps.py
+++ b/ci/release-validate-deps.py
@@ -20,8 +20,8 @@ if __name__ == '__main__':
         print('This repository is releasable because the dependencies are '
               'all release dependencies: {}'.format(sys.argv[1:]))
     else:
-        raise RuntimeError('Error: This commit is not releasable because '
+        raise RuntimeError('This commit is not releasable because '
                            'there are one or more snapshot dependencies: {}. '
                            'Check that every dependencies listed in {} are all release dependencies '
-                           '(ie., depends on a tag instead of a commit)'
+                           '(ie., depends on a tag instead of a commit).'
                            .format(snapshot_dependencies, dependencies_bzl))


### PR DESCRIPTION
The `//ci:release-validate-deps` can be used from the CI job to ensure that we're depending on a release instead of a snapshot dependency.

For example, if we are to release `graknlabs_grakn_core` which depends on a snapshot version of `graknlabs_common` will fail with the following error message:

```
bazel run @graknlabs_build_tools//ci:release-validate-deps graknlabs_graql graknlabs_common

RuntimeError: This commit is not releasable because there are one or more snapshot 
dependencies: ['graknlabs_common']. Check that every dependencies listed in 
dependencies/graknlabs/dependencies.bzl are all release dependencies 
(ie., depends on a tag instead of a commit).
```

If every dependency is a release dependency, it will succeed:
```
bazel run @graknlabs_build_tools//ci:release-validate-deps graknlabs_graql graknlabs_common

This repository is releasable because the dependencies
are all release dependencies: ['graknlabs_common', 'graknlabs_graql']
```