### PR TITLE
Fix code-analysis script to work with Python 3

### DIFF
--- a/sonarcloud/code-analysis.py
+++ b/sonarcloud/code-analysis.py
@@ -23,6 +23,7 @@ import glob
 import os
 import shutil
 import subprocess as sp
+import tempfile
 
 credential = os.getenv('SONARCLOUD_CODE_ANALYSIS_CREDENTIAL')
 if not credential:
@@ -37,7 +38,7 @@ args = parser.parse_args()
 
 tmpdir = None
 try:
-    tmpdir = sp.check_output(['mktemp', '-d']).strip()
+    tmpdir = tempfile.mkdtemp()
     sp.check_call(['unzip', '-qq',
         os.path.join('external', 'sonarscanner_zip', 'file', 'downloaded'), '-d', tmpdir])
     sp.check_call(['mv'] + glob.glob(os.path.join(tmpdir, 'sonar-scanner-*', '*')) + ['.'], cwd=tmpdir)


### PR DESCRIPTION
Python 3's version of `subprocess.check_call` returns `bytes` which need to be decoded before using as path component. To fix it, we use native method to create a temporary directory: `tempfile.mkdtemp()`