### PR TITLE
Fix //ci:test-cache to work with Python 3

### DIFF
--- a/ci/test-cache.py
+++ b/ci/test-cache.py
@@ -69,7 +69,7 @@ def check_output_discarding_stderr(*args, **kwargs):
 
 
 args = CMDLINE_PARSER.parse_args(sys.argv[1:])
-file_checksum = hashlib.sha256(open(args.file).read()).hexdigest()
+file_checksum = hashlib.sha256(open(args.file, 'rb').read()).hexdigest()
 
 if args.get:
     response = json.loads(check_output_discarding_stderr([


### PR DESCRIPTION
## What is the goal of this PR?

`//ci:test-cache` was non-operational due to incorrect usage of `hashlib`

## What are the changes implemented in this PR?

`hashlib.<algo>` expects `bytes` to calculate checksum of, so we open files in "read binary" (`rb`) mode
