### PR TITLE
Rename variable used to sign message in //ci:test-cache

### DIFF
--- a/ci/test-cache.py
+++ b/ci/test-cache.py
@@ -35,10 +35,10 @@ CMDLINE_GROUP_PARSER.add_argument('--get', dest='get', action='store_true')
 CMDLINE_GROUP_PARSER.add_argument('--save-success', dest='store', action='store_true')
 CMDLINE_GROUP_PARSER.set_defaults(store=None)
 
-git_token = os.getenv('RELEASE_APPROVAL_TOKEN')
+git_token = os.getenv('TEST_CACHE_TOKEN')
 
 if not git_token:
-    raise Exception('Environment variable $RELEASE_APPROVAL_TOKEN is not set!')
+    raise Exception('Environment variable $TEST_CACHE_TOKEN is not set!')
 
 if not os.getenv('CIRCLE_SHA1'):
     raise Exception('Environment variable $CIRCLE_SHA1 is not set!')


### PR DESCRIPTION
`RELEASE_APPROVAL_TOKEN` was not a proper name for a varialbe to be used in `//ci:test-cache` mainly because its purpose is not clear from its name. This PR names the variable properly.