### PR TITLE
Detect unused Java dependencies

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -90,3 +90,6 @@ node_repositories()
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_repositories")
 sass_repositories()
+
+load("//unused_deps:dependencies.bzl", "unused_deps_dependencies")
+unused_deps_dependencies()

--- a/unused_deps/BUILD
+++ b/unused_deps/BUILD
@@ -1,0 +1,10 @@
+py_binary(
+    name = "unused_deps",
+    srcs = ["unused_deps.py"],
+    data = [
+        "@unused_deps_mac//file",
+        "@unused_deps_linux//file",
+        "@buildozer_mac//file",
+        "@buildozer_linux//file",
+    ]
+)

--- a/unused_deps/dependencies.bzl
+++ b/unused_deps/dependencies.bzl
@@ -1,0 +1,41 @@
+#
+# GRAKN.AI - THE KNOWLEDGE GRAPH
+# Copyright (C) 2018 Grakn Labs Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+
+def unused_deps_dependencies():
+    http_file(
+        name = "unused_deps_mac",
+        urls = ["https://repo.grakn.ai/repository/meta/unused_deps-mac-7e793330b31d465f6bffe101ace2ab25d75e2eec"],
+        executable = True
+    )
+    http_file(
+        name = "unused_deps_linux",
+        urls = ["https://repo.grakn.ai/repository/meta/unused_deps-linux-7e793330b31d465f6bffe101ace2ab25d75e2eec"],
+        executable = True
+    )
+    http_file(
+        name = "buildozer_mac",
+        urls = ["https://repo.grakn.ai/repository/meta/buildozer-mac-7e793330b31d465f6bffe101ace2ab25d75e2eec"],
+        executable = True
+    )
+    http_file(
+        name = "buildozer_linux",
+        urls = ["https://repo.grakn.ai/repository/meta/buildozer-linux-7e793330b31d465f6bffe101ace2ab25d75e2eec"],
+        executable = True
+    )

--- a/unused_deps/unused_deps.py
+++ b/unused_deps/unused_deps.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import argparse
+import os
+import platform
+import subprocess
+from collections import defaultdict
+import re
+
+parser = argparse.ArgumentParser()
+parser.add_argument('mode', help="Operational mode", choices=['list', 'remove'])
+args = parser.parse_args()
+
+
+BUILDOZER_PATTERN = re.compile("buildozer 'remove deps (?P<dep>.*)' (?P<target>.*)")
+
+UNUSED_DEPS_BINARIES = {
+    "Darwin": os.path.abspath("external/unused_deps_mac/file/downloaded"),
+    "Linux": os.path.abspath("external/unused_deps_linux/file/downloaded"),
+}
+
+BUILDOZER_BINARIES = {
+    "Darwin": os.path.abspath("external/buildozer_mac/file/downloaded"),
+    "Linux": os.path.abspath("external/buildozer_linux/file/downloaded"),
+}
+
+system = platform.system()
+
+if system not in UNUSED_DEPS_BINARIES:
+    raise ValueError('unused_deps does not have binary for {}'.format(system))
+
+if system not in BUILDOZER_BINARIES:
+    raise ValueError('buildozer does not have binary for {}'.format(system))
+
+
+output = subprocess.check_output([
+    UNUSED_DEPS_BINARIES[system]
+], cwd=os.getenv('BUILD_WORKSPACE_DIRECTORY'), stderr=subprocess.STDOUT).decode()
+
+unused_deps = defaultdict(set)
+
+output_lines = output.split('\n')
+buildozer_commands = []
+for line in output_lines:
+    match = BUILDOZER_PATTERN.match(line)
+    if match:
+        buildozer_commands.append(line)
+        gd = match.groupdict()
+        unused_deps[gd['target']].add(gd['dep'])
+
+
+if args.mode == 'list':
+    if unused_deps:
+        print('\033[0;31mERROR: There are unused deps found:\033[0m')
+        for target, deps in unused_deps.items():
+            print('{}:'.format(target))
+            for dep in deps:
+                print('--> {}'.format(dep))
+        print('You can run "bazel run @graknlabs_build_tools//unused_deps -- remove" to fix it')
+        exit(1)
+    else:
+        print('\033[0;32mThere are no unused deps found.\033[0m')
+elif args.mode == 'remove':
+    for cmd in buildozer_commands:
+        subprocess.check_call([
+            cmd.replace('buildozer', BUILDOZER_BINARIES[system])
+        ], shell=True, cwd=os.getenv('BUILD_WORKSPACE_DIRECTORY'))


### PR DESCRIPTION
Fix #103
Sample usage:

```
bazel run @graknlabs_build_tools//unused_deps -- list
```

```
bazel run @graknlabs_build_tools//unused_deps -- remove
```