### PR TITLE
use JavaInfo instead of the now obsolete java attribute

### DIFF
--- a/distribution/maven/rules.bzl
+++ b/distribution/maven/rules.bzl
@@ -269,8 +269,8 @@ def _assemble_maven_impl(ctx):
 
     # there is also .source_jar which produces '.srcjar'
     if hasattr(target, "java"):
-        jar = target.java.outputs.jars[0].class_jar
-        srcjar = target.java.outputs.jars[0].source_jar
+        jar = target[JavaInfo].outputs.jars[0].class_jar
+        srcjar = target[JavaInfo].outputs.jars[0].source_jar
     elif hasattr(target, "files"):
         jar = target.files.to_list()[0]
     else:


### PR DESCRIPTION
The assemble_maven rule seems to be broken with bazel > 1.0.0
fails with the following error:
`object of type 'JavaSkylarkApiProvider' has no field 'outputs'`
This PR aims at fixing that issue.