### PR TITLE
Link 1.24.1 of @io_grpc_grpc_java

### DIFF
--- a/grpc/dependencies.bzl
+++ b/grpc/dependencies.bzl
@@ -25,6 +25,11 @@ def grpc_dependencies():
         commit = "4a1528f6f20a8aa68bdbdc9a66286ec2394fc170"
     )
     git_repository(
+        name = "io_grpc_grpc_java",
+        remote = "https://github.com/grpc/grpc-java",
+        commit = "b13d31c972fa5adf48a665659adc005c74d83024"
+    )
+    git_repository(
         name = "stackb_rules_proto",
         remote = "https://github.com/stackb/rules_proto",
         commit = "d9a123032f8436dbc34069cfc3207f2810a494ee",


### PR DESCRIPTION
In order to use upgraded `grpc`, we need to add a link to `io_grpc_grpc_java` such that `1.24.1` is used instead of `v1.19.0` pulled in by `rules_proto`. This allows us to not have to fork and maintain `rules_proto` 