### PR TITLE
Bump @io_grpc_grpc_java to a version with maven-https fix

### DIFF
--- a/grpc/dependencies.bzl
+++ b/grpc/dependencies.bzl
@@ -27,7 +27,7 @@ def grpc_dependencies():
     git_repository(
         name = "io_grpc_grpc_java",
         remote = "https://github.com/grpc/grpc-java",
-        commit = "b13d31c972fa5adf48a665659adc005c74d83024"
+        commit = "62e8655f1bc4dfb474afbf332ca7571c1454e6ef"
     )
     git_repository(
         name = "stackb_rules_proto",


### PR DESCRIPTION
Linked commit already contains fix for Maven HTTPS issue: https://github.com/graknlabs/grpc-java/commit/62e8655f1bc4dfb474afbf332ca7571c1454e6ef

This commit is chosen as the commit closest to 1.24.1, which is the gRPC version that we use.