### PR TITLE
Remove incompatible native.maven_jar usage

### DIFF
--- a/checkstyle/dependencies.bzl
+++ b/checkstyle/dependencies.bzl
@@ -16,6 +16,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+load("@bazel_tools//tools/build_defs/repo:jvm.bzl", "jvm_maven_import_external")
+
+
 def checkstyle_dependencies(
     omit = [],
     versions = {
@@ -31,47 +34,74 @@ def checkstyle_dependencies(
     }
 ):
   if not "antlr_antlr" in omit:
-    native.maven_jar(
+    jvm_maven_import_external(
         name = "antlr_antlr",
         artifact = "antlr:antlr:" + versions["antlr_antlr"],
+        artifact_sha256 = "88fbda4b912596b9f56e8e12e580cc954bacfb51776ecfddd3e18fc1cf56dc4c",
+        server_urls = ["https://repo1.maven.org/maven2/"],
+        licenses = ["notice"],
     )
   if not "org_antlr_antlr4_runtime" in omit:
-    native.maven_jar(
+    jvm_maven_import_external(
         name = "org_antlr_antlr4_runtime",
         artifact = "org.antlr:antlr4-runtime:" + versions["org_antlr_antlr4_runtime"],
+        artifact_sha256 = "ffca72bc2a25bb2b0c80a58cee60530a78be17da739bb6c91a8c2e3584ca099e",
+        server_urls = ["https://repo1.maven.org/maven2/"],
+        licenses = ["notice"],
     )
   if not "com_puppycrawl_tools_checkstyle" in omit:
-    native.maven_jar(
+    jvm_maven_import_external(
         name = "com_puppycrawl_tools_checkstyle",
         artifact = "com.puppycrawl.tools:checkstyle:" + versions["com_puppycrawl_tools_checkstyle"],
+        artifact_sha256 = "ac3602c4d50c3113b14614a6ac38ec03c63d9839e4316e057c4bb66d97183087",
+        server_urls = ["https://repo1.maven.org/maven2/"],
+        licenses = ["notice"],
     )
   if not "commons_beanutils_commons_beanutils" in omit:
-    native.maven_jar(
+    jvm_maven_import_external(
         name = "commons_beanutils_commons_beanutils",
         artifact = "commons-beanutils:commons-beanutils:" + versions["commons_beanutils_commons_beanutils"],
+        artifact_sha256 = "c058e39c7c64203d3a448f3adb588cb03d6378ed808485618f26e137f29dae73",
+        server_urls = ["https://repo1.maven.org/maven2/"],
+        licenses = ["notice"],
     )
   if not "info_picocli_picocli" in omit:
-    native.maven_jar(
+    jvm_maven_import_external(
         name = "info_picocli_picocli",
         artifact = "info.picocli:picocli:" + versions["info_picocli_picocli"],
+        artifact_sha256 = "b16786a3817530151ccc44ac44f1f803b9a1b4069e98c4d1ed2fc0ece12d6de7",
+        server_urls = ["https://repo1.maven.org/maven2/"],
+        licenses = ["notice"],
     )
   if not "commons_collections_commons_collections" in omit:
-    native.maven_jar(
+    jvm_maven_import_external(
         name = "commons_collections_commons_collections",
         artifact = "commons-collections:commons-collections:" + versions["commons_collections_commons_collections"],
+        artifact_sha256 = "eeeae917917144a68a741d4c0dff66aa5c5c5fd85593ff217bced3fc8ca783b8",
+        server_urls = ["https://repo1.maven.org/maven2/"],
+        licenses = ["notice"],
     )
   if not "com_google_guava_guava23" in omit:
-    native.maven_jar(
+    jvm_maven_import_external(
         name = "com_google_guava_guava23",
         artifact = "com.google.guava:guava:" + versions["com_google_guava_guava23"],
+        artifact_sha256 = "7baa80df284117e5b945b19b98d367a85ea7b7801bd358ff657946c3bd1b6596",
+        server_urls = ["https://repo1.maven.org/maven2/"],
+        licenses = ["notice"],
     )
   if not "org_slf4j_slf4j_api" in omit:
-    native.maven_jar(
+    jvm_maven_import_external(
         name = "org_slf4j_slf4j_api",
         artifact = "org.slf4j:slf4j-api:" + versions["org_slf4j_slf4j_api"],
+        artifact_sha256 = "69980c038ca1b131926561591617d9c25fabfc7b29828af91597ca8570cf35fe",
+        server_urls = ["https://repo1.maven.org/maven2/"],
+        licenses = ["notice"],
     )
   if not "org_slf4j_slf4j_jcl" in omit:
-    native.maven_jar(
+    jvm_maven_import_external(
         name = "org_slf4j_slf4j_jcl",
         artifact = "org.slf4j:jcl-over-slf4j:" + versions["org_slf4j_slf4j_jcl"],
+        artifact_sha256 = "c6472b5950e1c23202e567c6334e4832d1db46fad604b7a0d7af71d4a014bce2",
+        server_urls = ["https://repo1.maven.org/maven2/"],
+        licenses = ["notice"],
     )


### PR DESCRIPTION
Bazel 2.0 removes `maven_jar` from native rules. In order for us to migrate to newer Bazel, `checkstyle_dependencies` need to be adapted according to guide in bazelbuild/bazel#6799