### PR TITLE
Update reference to a fixed bazel distr with green build

### DIFF
--- a/distribution/deps.bzl
+++ b/distribution/deps.bzl
@@ -9,5 +9,5 @@ def vaticle_bazel_distribution():
     git_repository(
         name = "vaticle_bazel_distribution",
         remote = "https://github.com/vaticle/bazel-distribution",
-        commit = "5e8c09ddbb20571c8a48651210494ac68fcf8ae7" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
+        commit = "425493c9a92ef894b99b3b8071886dd2af8098cf" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_bazel_distribution
     )


### PR DESCRIPTION
We update the reference to the bazel-distribution with a [commit](https://github.com/vaticle/bazel-distribution/commit/425493c9a92ef894b99b3b8071886dd2af8098cf), that fixes Bazel build issues.
