### PR TITLE
Re-implement native_artifact_files as module_extension

### DIFF
--- a/distribution/artifact/rules.bzl
+++ b/distribution/artifact/rules.bzl
@@ -4,6 +4,16 @@
 
 
 load("@typedb_bazel_distribution//artifact:rules.bzl", "artifact_file")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+
+public_artifact_sources = struct(
+    release  = "https://repo.typedb.com/public/public-release/raw/",
+    snapshot = "https://repo.typedb.com/public/public-snapshot/raw/",
+)
+private_artifact_sources = struct(
+    release  = "https://repo.typedb.com/basic/private-release/raw/",
+    snapshot = "https://repo.typedb.com/basic/private-snapshot/raw/",
+)
 
 platform_extension = {
     "linux-arm64": "tar.gz",
@@ -12,17 +22,6 @@ platform_extension = {
     "mac-x86_64": "zip",
     "windows-x86_64": "zip",
 }
-
-def native_artifact_files(name, artifact_name, group_name, **kwargs):
-    for platform, ext in platform_extension.items():
-        artifact_file(
-            name = name + "_" + platform,
-            group_name = group_name.replace("{platform}", platform).replace("{ext}", ext),
-            # Can't use .format() because the result string will still have the unresolved parameter {version}
-            artifact_name = artifact_name.replace("{platform}", platform).replace("{ext}", ext),
-            **kwargs,
-        )
-
 
 def artifact_repackage(name, srcs, files_to_keep):
     native.genrule(
@@ -34,3 +33,58 @@ def artifact_repackage(name, srcs, files_to_keep):
         ),
         tools = ["@typedb_dependencies//distribution/artifact:artifact-repackage"]
     )
+
+def _native_artifact_files_impl(ctx):
+    for mod in ctx.modules:
+        for artifact in mod.tags.artifact:
+              for platform, ext in platform_extension.items():
+                    target_name = artifact.name + "_" + platform
+                    group_name = artifact.group_name.replace("{platform}", platform).replace("{ext}", ext)
+                    # Can't use .format() because the result string will still have the unresolved parameter {version}
+                    artifact_name = artifact.artifact_name.replace("{platform}", platform).replace("{ext}", ext)
+
+                    version = artifact.tag if artifact.tag != None else artifact.commit
+                    if artifact.private == True:
+                        repository_url = private_artifact_sources.release if artifact.tag != None else private_artifact_sources.snapshot
+                    else:
+                        repository_url = public_artifact_sources.release if artifact.tag != None else public_artifact_sources.snapshot
+                    artifact_name = artifact_name.format(version = version)
+                    http_file(
+                        name = target_name,
+                        urls = ["{}/names/{}/versions/{}/{}".format(repository_url.rstrip("/"), group_name, version, artifact_name)],
+                        downloaded_file_path = artifact_name,
+                    )
+
+_artifact_tag = tag_class(
+    attrs = {
+        "name": attr.string(
+            mandatory = True,
+            doc       = "Base name for the generated repos.",
+        ),
+        "group_name": attr.string(
+            mandatory = True,
+            doc       = "Group path template, may contain {platform}.",
+        ),
+        "artifact_name": attr.string(
+            mandatory = True,
+            doc       = "Filename template, may contain {platform}, {version}, {ext}.",
+        ),
+        "tag": attr.string(
+            default = "",
+            doc     = "Version tag to use when resolving release URLs.",
+        ),
+        "commit": attr.string(
+            default = "",
+            doc     = "Commit SHA to use when resolving snapshot URLs.",
+        ),
+        "private": attr.bool(
+            default = False,
+            doc     = "Load the artifact from a private repository",
+        ),
+    },
+)
+
+native_artifact_files = module_extension(
+    implementation = _native_artifact_files_impl,
+    tag_classes    = {"artifact": _artifact_tag},
+)


### PR DESCRIPTION
## Usage and product changes
Re-implements `native_artifact_files` as module_extension.
Usage:
```
native_artifact_files = use_extension("@typedb_dependencies//distribution/artifact:rules.bzl", "native_artifact_files")

native_artifact_files.artifact(
    name = "typedb_console_artifact",
    group_name = "typedb-console-{platform}",
    artifact_name = "typedb-console-{platform}-{version}.{ext}",
    tag = "3.8.0",
)

use_repo(
    native_artifact_files,
     "typedb_console_artifact_linux-x86_64",
     "typedb_console_artifact_linux-arm64",
     "typedb_console_artifact_mac-x86_64",
     "typedb_console_artifact_mac-arm64",
     "typedb_console_artifact_windows-x86_64",
)
```

## Motivation
Re-implement in bazel 8.

