### PR TITLE
Bump typedb-common maven dependency to newer snapshot

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -86,6 +86,8 @@
     "https://bcr.bazel.build/modules/rules_cc/0.0.9/MODULE.bazel": "836e76439f354b89afe6a911a7adf59a6b2518fafb174483ad78a2a2fde7b1c5",
     "https://bcr.bazel.build/modules/rules_cc/0.1.1/MODULE.bazel": "2f0222a6f229f0bf44cd711dc13c858dad98c62d52bd51d8fc3a764a83125513",
     "https://bcr.bazel.build/modules/rules_cc/0.1.1/source.json": "d61627377bd7dd1da4652063e368d9366fc9a73920bfa396798ad92172cf645c",
+    "https://bcr.bazel.build/modules/rules_dotnet/0.14.0/MODULE.bazel": "f006f845f5e75c5a3e691947062bf33cfef66d2b66af9f1d5f6a35fc99d4ed78",
+    "https://bcr.bazel.build/modules/rules_dotnet/0.14.0/source.json": "0fd3ac33da1afa98261a99251396e99eab82261739aa81beee6c814cc83b897e",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
     "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/MODULE.bazel": "40c97d1144356f52905566c55811f13b299453a14ac7769dfba2ac38192337a8",
     "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/source.json": "c8b1e2c717646f1702290959a3302a178fb639d987ab61d548105019f11e527e",
@@ -162,7 +164,7 @@
   "moduleExtensions": {
     "//library/maven:maven_extension.bzl%maven": {
       "general": {
-        "bzlTransitiveDigest": "xMWpLSMTFb8Mnv/A2T5iiIIV6+62B5LCSeaPDQfgIik=",
+        "bzlTransitiveDigest": "a1y2bC0JvzQ9DuywiQJ0qwoc5tZsjCPo9SZEXXml0Zo=",
         "usagesDigest": "GD8WWDyl5JpTrILXbJy2Aj9ll4pyhkO/BOc89gMMfUg=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -433,7 +435,7 @@
                 "{ \"group\": \"com.vdurmont\", \"artifact\": \"semver4j\", \"version\": \"3.1.0\" }",
                 "{ \"group\": \"com.vaticle.typedb\", \"artifact\": \"typedb-runner\", \"version\": \"2.28.3\" }",
                 "{ \"group\": \"com.vaticle.typedb\", \"artifact\": \"typedb-cloud-runner\", \"version\": \"2.28.3\" }",
-                "{ \"group\": \"com.vaticle.typedb\", \"artifact\": \"typedb-common\", \"version\": \"0.0.0-56ed57603e67103d0a371721db2d15e7e727ccac\" }",
+                "{ \"group\": \"com.typedb\", \"artifact\": \"typedb-common\", \"version\": \"0.0.0-23578fb766fbf78b2327a59eb9ce6d00ced1623f\" }",
                 "{ \"group\": \"com.vaticle.typedb\", \"artifact\": \"typedb-driver\", \"version\": \"2.28.0-rc0\" }",
                 "{ \"group\": \"com.vaticle.typeql\", \"artifact\": \"typeql-lang\", \"version\": \"2.28.0\" }",
                 "{ \"group\": \"aws.sdk.kotlin\", \"artifact\": \"ebs-jvm\", \"version\": \"1.3.23\" }",
@@ -478,6 +480,72 @@
             "",
             "rules_jvm_external",
             "rules_jvm_external+"
+          ]
+        ]
+      }
+    },
+    "@@rules_dotnet+//dotnet:extensions.bzl%dotnet": {
+      "general": {
+        "bzlTransitiveDigest": "rjQ1lfCCmBPTcuoXxuj+2PRXph88EtNicFgnepUslJM=",
+        "usagesDigest": "y75g1jmYU1fblpSxK54Wn05KoJnAdHF2DKN2jEzjg8U=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "dotnet_x86_64-apple-darwin": {
+            "repoRuleId": "@@rules_dotnet+//dotnet:repositories.bzl%dotnet_repositories",
+            "attributes": {
+              "platform": "x86_64-apple-darwin",
+              "dotnet_version": "8.0.100"
+            }
+          },
+          "dotnet_aarch64-apple-darwin": {
+            "repoRuleId": "@@rules_dotnet+//dotnet:repositories.bzl%dotnet_repositories",
+            "attributes": {
+              "platform": "aarch64-apple-darwin",
+              "dotnet_version": "8.0.100"
+            }
+          },
+          "dotnet_x86_64-unknown-linux-gnu": {
+            "repoRuleId": "@@rules_dotnet+//dotnet:repositories.bzl%dotnet_repositories",
+            "attributes": {
+              "platform": "x86_64-unknown-linux-gnu",
+              "dotnet_version": "8.0.100"
+            }
+          },
+          "dotnet_arm64-unknown-linux-gnu": {
+            "repoRuleId": "@@rules_dotnet+//dotnet:repositories.bzl%dotnet_repositories",
+            "attributes": {
+              "platform": "arm64-unknown-linux-gnu",
+              "dotnet_version": "8.0.100"
+            }
+          },
+          "dotnet_x86_64-pc-windows-msvc": {
+            "repoRuleId": "@@rules_dotnet+//dotnet:repositories.bzl%dotnet_repositories",
+            "attributes": {
+              "platform": "x86_64-pc-windows-msvc",
+              "dotnet_version": "8.0.100"
+            }
+          },
+          "dotnet_arm64-pc-windows-msvc": {
+            "repoRuleId": "@@rules_dotnet+//dotnet:repositories.bzl%dotnet_repositories",
+            "attributes": {
+              "platform": "arm64-pc-windows-msvc",
+              "dotnet_version": "8.0.100"
+            }
+          },
+          "dotnet_toolchains": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private:toolchains_repo.bzl%toolchains_repo",
+            "attributes": {
+              "user_repository_name": "dotnet"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_dotnet+",
+            "bazel_tools",
+            "bazel_tools"
           ]
         ]
       }

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -164,7 +164,7 @@
   "moduleExtensions": {
     "//library/maven:maven_extension.bzl%maven": {
       "general": {
-        "bzlTransitiveDigest": "a1y2bC0JvzQ9DuywiQJ0qwoc5tZsjCPo9SZEXXml0Zo=",
+        "bzlTransitiveDigest": "Lc0HHPD47+zUM5FwHlV7/6hQgmhcQXmrUx7Un+Zf/DE=",
         "usagesDigest": "GD8WWDyl5JpTrILXbJy2Aj9ll4pyhkO/BOc89gMMfUg=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -435,7 +435,7 @@
                 "{ \"group\": \"com.vdurmont\", \"artifact\": \"semver4j\", \"version\": \"3.1.0\" }",
                 "{ \"group\": \"com.vaticle.typedb\", \"artifact\": \"typedb-runner\", \"version\": \"2.28.3\" }",
                 "{ \"group\": \"com.vaticle.typedb\", \"artifact\": \"typedb-cloud-runner\", \"version\": \"2.28.3\" }",
-                "{ \"group\": \"com.typedb\", \"artifact\": \"typedb-common\", \"version\": \"0.0.0-23578fb766fbf78b2327a59eb9ce6d00ced1623f\" }",
+                "{ \"group\": \"com.vaticle.typedb\", \"artifact\": \"typedb-common\", \"version\": \"0.0.0-0adb2c44a35a4518984e046bb07611abf8d31a97\" }",
                 "{ \"group\": \"com.vaticle.typedb\", \"artifact\": \"typedb-driver\", \"version\": \"2.28.0-rc0\" }",
                 "{ \"group\": \"com.vaticle.typeql\", \"artifact\": \"typeql-lang\", \"version\": \"2.28.0\" }",
                 "{ \"group\": \"aws.sdk.kotlin\", \"artifact\": \"ebs-jvm\", \"version\": \"1.3.23\" }",

--- a/library/maven/bzlmod_artifacts.bzl
+++ b/library/maven/bzlmod_artifacts.bzl
@@ -265,7 +265,7 @@ MAVEN_ARTIFACTS = [
     # TypeDB/Vaticle artifacts (used by typedb-cloud)
     "com.vaticle.typedb:typedb-runner:2.28.3",
     "com.vaticle.typedb:typedb-cloud-runner:2.28.3",
-    "com.vaticle.typedb:typedb-common:0.0.0-23578fb766fbf78b2327a59eb9ce6d00ced1623f",
+    "com.typedb:typedb-common:0.0.0-23578fb766fbf78b2327a59eb9ce6d00ced1623f",
     "com.vaticle.typedb:typedb-driver:2.28.0-rc0",
     "com.vaticle.typeql:typeql-lang:2.28.0",
 

--- a/library/maven/bzlmod_artifacts.bzl
+++ b/library/maven/bzlmod_artifacts.bzl
@@ -265,7 +265,7 @@ MAVEN_ARTIFACTS = [
     # TypeDB/Vaticle artifacts (used by typedb-cloud)
     "com.vaticle.typedb:typedb-runner:2.28.3",
     "com.vaticle.typedb:typedb-cloud-runner:2.28.3",
-    "com.vaticle.typedb:typedb-common:0.0.0-56ed57603e67103d0a371721db2d15e7e727ccac",
+    "com.vaticle.typedb:typedb-common:0.0.0-23578fb766fbf78b2327a59eb9ce6d00ced1623f",
     "com.vaticle.typedb:typedb-driver:2.28.0-rc0",
     "com.vaticle.typeql:typeql-lang:2.28.0",
 

--- a/library/maven/bzlmod_artifacts.bzl
+++ b/library/maven/bzlmod_artifacts.bzl
@@ -265,7 +265,9 @@ MAVEN_ARTIFACTS = [
     # TypeDB/Vaticle artifacts (used by typedb-cloud)
     "com.vaticle.typedb:typedb-runner:2.28.3",
     "com.vaticle.typedb:typedb-cloud-runner:2.28.3",
-    "com.typedb:typedb-common:0.0.0-23578fb766fbf78b2327a59eb9ce6d00ced1623f",
+    # Warning - Cloud is still using `com.vaticle.typedb`. master has `com.typedb`.
+    # This must come from the `typedb-cloud-common` branch
+    "com.vaticle.typedb:typedb-common:0.0.0-0adb2c44a35a4518984e046bb07611abf8d31a97",
     "com.vaticle.typedb:typedb-driver:2.28.0-rc0",
     "com.vaticle.typeql:typeql-lang:2.28.0",
 


### PR DESCRIPTION
## Usage and product changes
Bumps the typedb-common maven dependency to a newer snapshot, so repositories that use any form of maven are unblocked.

## Implementation:
I've also moved the snapshot to `public-release` so it doesn't get cleaned up abruptly one day.