### PR TITLE
Add extracted version of native_artifacts to easily select files for repackaging

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -340,7 +340,7 @@ bazel_dep(name = "typedb_bazel_distribution", version = "0.0.0")
 git_override(
     module_name = "typedb_bazel_distribution",
     remote = "https://github.com/typedb/bazel-distribution",
-    commit = "c34c0c513e45e69e3f9d97664c7ccb5afd5f1341",
+    commit = "dd811cf28715bbce8374e5e0f9defaf772e7dd36",
 )
 
 # ===========================================================

--- a/distribution/artifact/rules.bzl
+++ b/distribution/artifact/rules.bzl
@@ -42,8 +42,11 @@ def _native_artifact_files_impl(ctx):
                     group_name = artifact.group_name.replace("{platform}", platform).replace("{ext}", ext)
                     # Can't use .format() because the result string will still have the unresolved parameter {version}
                     artifact_name = artifact.artifact_name.replace("{platform}", platform).replace("{ext}", ext)
-
                     version = artifact.tag if artifact.tag else artifact.commit
+                    if artifact.archive_strip_prefix != None:
+                        archive_strip_prefix = artifact.archive_strip_prefix.replace("{platform}", platform).replace("{version}", version)
+                    else:
+                        archive_strip_prefix = None
                     if artifact.private == True:
                         repository_url = private_artifact_sources.release if artifact.tag else private_artifact_sources.snapshot
                     else:
@@ -57,6 +60,7 @@ def _native_artifact_files_impl(ctx):
                     http_archive(
                         name = target_name + "-extracted",
                         urls = ["{}/names/{}/versions/{}/{}".format(repository_url.rstrip("/"), group_name, version, artifact_name)],
+                        strip_prefix = archive_strip_prefix,
                         build_file_content = """
 filegroup(
     name = "all_files",
@@ -92,6 +96,11 @@ _artifact_tag = tag_class(
             default = False,
             doc     = "Load the artifact from a private repository",
         ),
+        "archive_strip_prefix": attr.string(
+            mandatory = False,
+            doc     = "The prefix to strip from the archive, may contain {platform}, {version}.",
+            # Replace with strip_components if we upgrade to bazel 9
+        )
     },
 )
 

--- a/distribution/artifact/rules.bzl
+++ b/distribution/artifact/rules.bzl
@@ -4,7 +4,7 @@
 
 
 load("@typedb_bazel_distribution//artifact:rules.bzl", "artifact_file")
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file", "http_archive")
 
 public_artifact_sources = struct(
     release  = "https://repo.typedb.com/public/public-release/raw/",
@@ -53,6 +53,17 @@ def _native_artifact_files_impl(ctx):
                         name = target_name,
                         urls = ["{}/names/{}/versions/{}/{}".format(repository_url.rstrip("/"), group_name, version, artifact_name)],
                         downloaded_file_path = artifact_name,
+                    )
+                    http_archive(
+                        name = target_name + "-extracted",
+                        urls = ["{}/names/{}/versions/{}/{}".format(repository_url.rstrip("/"), group_name, version, artifact_name)],
+                        build_file_content = """
+filegroup(
+    name = "all_files",
+    srcs = glob(["**/*"]),
+    visibility = ["//visibility:public"],
+)
+                        """
                     )
 
 _artifact_tag = tag_class(


### PR DESCRIPTION
## Usage and product changes
Adds flexibility to our repackaging rules by making the files within the archive transparent to bazel
Example:
```
native_artifact_files.artifact(
    name = "typedb_console_artifact",
    group_name = "typedb-console-{platform}",
    artifact_name = "typedb-console-{platform}-{version}.{ext}",
    archive_strip_prefix = "typedb-console-{platform}-{version}", # For predictable paths
    tag = "3.11.5",
)

# No need for a custom rule to repackage, we can easily select files.
select_file(
    name = "console-binary-only",
    srcs = ":typedb_console_artifact_extracted",
    subpath = "console/typedb_console_bin",
)

```

 

