### PR TITLE
Add comment for prebuilt cargo-bazel

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -8,6 +8,10 @@ build:
       image: typedb-ubuntu-22.04
       command: |
         sudo apt-get install -y libtinfo5
+        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
+            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
+            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
+        fi
         bazel build //...
         bazel test $(bazel query 'kind(checkstyle_test, //... except tool/ide/...)') || exit 1
     validate-all-maven-deps-build:
@@ -21,6 +25,10 @@ build:
       command: |
         library/crates/get_cargo.sh
         export PATH=$PATH:$PWD
+        if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
+            export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
+            export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
+        fi
         cd tool/ide/test/
         bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=streamed || exit 1
         tool/ide/rust/sync.sh

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -179,6 +179,9 @@ crate.from_cargo(
         "x86_64-pc-windows-msvc",
         "x86_64-unknown-linux-gnu",
     ],
+    # The cargo-bazel tool doesn't get cached for whatever reason. To use a precompiled one:
+    #  * If this rule ever supports a `generator` attribute (crates_repository does), set it.
+    #  * Till then, set CARGO_BAZEL_GENERATOR_URL to the appropriate one from cloudsmith.
 )
 crate.annotation(
     crate = "cbindgen",


### PR DESCRIPTION
## Usage and product changes
Adds a comment to the our crates repository initialisation in MODULE.bazel to set `CARGO_BAZEL_GENERATOR_URL` and replace it as soon as a `generator` attribute becomes available.
