### PR TITLE
Fix data dependencies of release_validate_deps tool

### DIFF
--- a/tool/release/deps/rules.bzl
+++ b/tool/release/deps/rules.bzl
@@ -63,6 +63,7 @@ def release_validate_deps(name, **kwargs):
     kt_jvm_test(
         name = name,
         main_class = "com.typedb.dependencies.tool.release.deps." + standard_name + "_genKt",
+        data = [kwargs["refs"], kwargs["version_file"]],
         srcs = [target_name],
         deps = [
             "@typedb_maven//:com_eclipsesource_minimal_json_minimal_json"


### PR DESCRIPTION
## Usage and product changes
Add the version_file and workspace refs json to the dat attribute of the kotlin for validating release deps tool
