### PR TITLE
Allow tag prefixes for validate release notes 

### DIFF
--- a/tool/release/notes/Commit.kt
+++ b/tool/release/notes/Commit.kt
@@ -56,18 +56,18 @@ private fun getPrecedingVersion(org: String, repo: String, version: Version, git
     return preceding
 }
 
-fun getLastVersion(org: String, repo: String, githubToken: String): Version? {
+fun getLastVersion(org: String, repo: String, githubToken: String, tagPrefix: String?): Version? {
     val response = httpGet("$github/repos/$org/$repo/releases", githubToken)
     val body = Json.parse(response.parseAsString())
     val tags = mutableListOf<Version>()
-    tags.addAll(body.asArray().mapNotNull(::parseTagVersion))
+    tags.addAll(body.asArray().mapNotNull { parseTagVersion(it, tagPrefix) })
     tags.sort()
     return tags.lastOrNull()
 }
 
-private fun parseTagVersion(release: JsonValue, prefix: String? = null): Version? {
+private fun parseTagVersion(release: JsonValue, tagPrefix: String?): Version? {
     val baseTag = release.asObject().get("tag_name").asString()
-    if (prefix.isNullOrBlank()) return Version.parse(baseTag)
-    if (!baseTag.startsWith(prefix)) return null
+    if (tagPrefix.isNullOrBlank()) return Version.parse(baseTag)
+    if (!baseTag.startsWith(tagPrefix)) return null
     return Version.parse(baseTag.removePrefix(baseTag))
 }

--- a/tool/release/notes/Commit.kt
+++ b/tool/release/notes/Commit.kt
@@ -7,6 +7,7 @@
 package com.typedb.dependencies.tool.release.notes
 
 import com.eclipsesource.json.Json
+import com.eclipsesource.json.JsonValue
 import com.typedb.dependencies.tool.release.notes.Constant.github
 import com.typedb.dependencies.tool.common.Version
 import java.nio.file.Path
@@ -59,8 +60,14 @@ fun getLastVersion(org: String, repo: String, githubToken: String): Version? {
     val response = httpGet("$github/repos/$org/$repo/releases", githubToken)
     val body = Json.parse(response.parseAsString())
     val tags = mutableListOf<Version>()
-    tags.addAll(body.asArray().map { release -> Version.parse(release.asObject().get("tag_name").asString()) })
+    tags.addAll(body.asArray().mapNotNull(::parseTagVersion))
     tags.sort()
-    if (tags.size == 0) return null;
-    else return tags.last();
+    return tags.lastOrNull()
+}
+
+private fun parseTagVersion(release: JsonValue, prefix: String? = null): Version? {
+    val baseTag = release.asObject().get("tag_name").asString()
+    if (prefix.isNullOrBlank()) return Version.parse(baseTag)
+    if (!baseTag.startsWith(prefix)) return null
+    return Version.parse(baseTag.removePrefix(baseTag))
 }

--- a/tool/release/notes/NotesValidate.kt
+++ b/tool/release/notes/NotesValidate.kt
@@ -12,13 +12,14 @@ import kotlin.io.path.notExists
 fun main(args: Array<String>) {
     val bazelWorkspaceDir = Paths.get(getEnv("BUILD_WORKSPACE_DIRECTORY"))
     val githubToken = getEnv("NOTES_VALIDATE_TOKEN")
-    if (args.size != 3) throw RuntimeException("org, repo, release notes file must be supplied")
+    if (args.size < 3 || args.size > 4) throw RuntimeException("Args: <org> <repo> <release notes file> [release tag prefix]")
 
     val org = args[0]
     val repo = args[1]
     val releaseNotesFile = args[2]
     val releaseNotesPath = bazelWorkspaceDir.resolve(releaseNotesFile)
     if (releaseNotesPath.notExists()) throw RuntimeException("Release notes file '$releaseNotesPath' does not exist.")
+    val releasePrefix = if (args.size > 3) args.get(3) else null
 
     val lastTag = getLastVersion(org, repo, githubToken)
 

--- a/tool/release/notes/NotesValidate.kt
+++ b/tool/release/notes/NotesValidate.kt
@@ -19,9 +19,9 @@ fun main(args: Array<String>) {
     val releaseNotesFile = args[2]
     val releaseNotesPath = bazelWorkspaceDir.resolve(releaseNotesFile)
     if (releaseNotesPath.notExists()) throw RuntimeException("Release notes file '$releaseNotesPath' does not exist.")
-    val releasePrefix = if (args.size > 3) args.get(3) else null
+    val tagPrefix = if (args.size > 3) args.get(3) else null
 
-    val lastTag = getLastVersion(org, repo, githubToken)
+    val lastTag = getLastVersion(org, repo, githubToken, tagPrefix)
 
     val result = bash("git diff --exit-code --quiet $lastTag HEAD -- $releaseNotesFile", bazelWorkspaceDir, false)
     if (result.getExitValue() == 0) {


### PR DESCRIPTION
## Usage and product changes

Introduce an optional fourth parameter to release note validation to indicate a "release tag prefix".

If provided, when searching for the last release tag it will only consider release tags with that prefix, and remove it before parsing them as versions.

## Motivation

Support the release flow of https://github.com/typedb/typedb-console, which releases multiple artifacts with different prefix tags (`console-x.y.z`, `loader-x.y.z`).

## Implementation

Add the arg to `NotesValidate.kt`, use it in `getLastVersion` in `Commit.kt`.