### PR TITLE
Allow notes generation to respect a multi-product release setup

### DIFF
--- a/tool/release/notes/BUILD
+++ b/tool/release/notes/BUILD
@@ -23,12 +23,13 @@ kt_jvm_binary(
 kt_jvm_binary(
     name = "create",
     srcs = glob(["NotesCreate.kt", "Note.kt", "Commit.kt", "Common.kt"]),
-    main_class = "com.typedb.dependencies.tool.release.notes.NotesCreateKt",
+    main_class = "com.typedb.dependencies.tool.release.notes.NotesCreate",
     deps = [
         "//tool/common:version",
         "@typedb_maven//:com_eclipsesource_minimal_json_minimal_json",
         "@typedb_maven//:com_google_http_client_google_http_client",
         "@typedb_maven//:org_zeroturnaround_zt_exec",
+        "@typedb_maven//:info_picocli_picocli",
     ],
 )
 

--- a/tool/release/notes/Commit.kt
+++ b/tool/release/notes/Commit.kt
@@ -7,19 +7,23 @@
 package com.typedb.dependencies.tool.release.notes
 
 import com.eclipsesource.json.Json
+import com.eclipsesource.json.JsonObject
 import com.eclipsesource.json.JsonValue
 import com.typedb.dependencies.tool.release.notes.Constant.github
 import com.typedb.dependencies.tool.common.Version
 import java.nio.file.Path
 
-fun collectCommits(org: String, repo: String, commit: String, version: Version, baseDir: Path, githubToken: String): List<String> {
+fun collectCommits(
+    org: String, repo: String, commit: String, version: Version, baseDir: Path,
+    githubToken: String, releaseTagPrefix: String?, excludedPaths: List<String>, includedPaths: List<String>
+): List<String> {
     println("Determining the commits to be collected...")
-    val preceding = getPrecedingVersion(org, repo, version, githubToken)
+    val preceding = getPrecedingVersion(org, repo, version, githubToken, releaseTagPrefix)
     if (preceding != null) {
         println("The script will collect commits down to the preceding version '$preceding'.")
         val response = httpGet("$github/repos/$org/$repo/compare/$preceding...$commit", githubToken)
         val body = Json.parse(response.parseAsString())
-        return body.asObject().get("commits").asArray().map { cmt -> cmt.asObject().get("sha").asString() }
+        return body.asObject().get("commits").asArray().mapNotNull { mayGetCommitSha(it.asObject(), excludedPaths, includedPaths, githubToken) }
     }
     else {
         val gitRevList = bash("git rev-list --max-parents=0 HEAD", baseDir)
@@ -28,17 +32,38 @@ fun collectCommits(org: String, repo: String, commit: String, version: Version, 
         val response = httpGet("$github/repos/$org/$repo/compare/$firstCommit...$commit", githubToken)
         val body = Json.parse(response.parseAsString())
         val commits =
-            body.asObject().get("commits").asArray().map { cmt -> cmt.asObject().get("sha").asString() }.toList()
+            body.asObject().get("commits").asArray().mapNotNull { mayGetCommitSha(it.asObject(), excludedPaths, includedPaths, githubToken) }.toList()
         return listOf(firstCommit) + commits
     }
 }
 
-private fun getPrecedingVersion(org: String, repo: String, version: Version, githubToken: String): Version? {
+fun mayGetCommitSha(commit: JsonObject, excludedPaths: List<String>, includedPaths: List<String>, githubToken: String): String? {
+    val commitUrl = commit.get("commit").asObject().get("url").asString().replace("/git", "")
+    val commitDetails = Json.parse(httpGet(commitUrl, githubToken).parseAsString()).asObject()
+    val hasRelevantFileChange = hasRelevantFileChange(commitDetails.get("files").asArray().map { it.asObject().get("filename").asString() }, excludedPaths, includedPaths)
+    return if (hasRelevantFileChange) commit.get("sha").asString() else null
+}
+
+private fun hasRelevantFileChange(
+    files: List<String>,
+    excludedPaths: List<String>,
+    includedPaths: List<String>,
+): Boolean {
+    includedPaths.forEach { included ->
+        if (files.any { it.startsWith(included) }) return true
+    }
+    excludedPaths.forEach { excluded ->
+        if (files.any { it.startsWith(excluded) }) return false
+    }
+    return true
+}
+
+private fun getPrecedingVersion(org: String, repo: String, version: Version, githubToken: String, releaseTagPrefix: String?): Version? {
     val response = httpGet("$github/repos/$org/$repo/releases", githubToken)
     val body = Json.parse(response.parseAsString())
     val tags = mutableListOf<Version>()
     tags.add(version)
-    tags.addAll(body.asArray().map { release -> Version.parse(release.asObject().get("tag_name").asString()) })
+    tags.addAll(body.asArray().mapNotNull { parseTagVersion(it, releaseTagPrefix) })
     tags.sort()
     val currentIdx = tags.indexOf(version)
     val preceding = when {
@@ -69,5 +94,5 @@ private fun parseTagVersion(release: JsonValue, tagPrefix: String?): Version? {
     val baseTag = release.asObject().get("tag_name").asString()
     if (tagPrefix.isNullOrBlank()) return Version.parse(baseTag)
     if (!baseTag.startsWith(tagPrefix)) return null
-    return Version.parse(baseTag.removePrefix(baseTag))
+    return Version.parse(baseTag.removePrefix(tagPrefix))
 }

--- a/tool/release/notes/Commit.kt
+++ b/tool/release/notes/Commit.kt
@@ -38,6 +38,8 @@ fun collectCommits(
 }
 
 fun mayGetCommitSha(commit: JsonObject, excludedPaths: List<String>, includedPaths: List<String>, githubToken: String): String? {
+    if (excludedPaths.isEmpty() && includedPaths.isEmpty()) return commit.get("sha").asString()
+
     val commitUrl = commit.get("commit").asObject().get("url").asString().replace("/git", "")
     val commitDetails = Json.parse(httpGet(commitUrl, githubToken).parseAsString()).asObject()
     val hasRelevantFileChange = hasRelevantFileChange(commitDetails.get("files").asArray().map { it.asObject().get("filename").asString() }, excludedPaths, includedPaths)

--- a/tool/release/notes/NotesCreate.kt
+++ b/tool/release/notes/NotesCreate.kt
@@ -9,58 +9,69 @@ package com.typedb.dependencies.tool.release.notes
 import com.typedb.dependencies.tool.common.Version
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.util.concurrent.Callable
+import picocli.CommandLine
 import kotlin.io.path.notExists
+import kotlin.system.exitProcess
 import kotlin.text.Regex.Companion.escapeReplacement
 
-fun main(args: Array<String>) {
-    val bazelWorkspaceDir = Paths.get(getEnv("BUILD_WORKSPACE_DIRECTORY"))
-    val githubToken = getEnv("NOTES_CREATE_TOKEN")
-    if (args.size < 6) throw RuntimeException("org, repo, commit, version, template, and output destination must be supplied")
+object NotesCreate: Callable<Int> {
 
-    operator fun <T> Array<T>.component6() = this[5]
-    val (org, repo, commit, version, templateFileLocation, outputFileLocation) = args
+    @CommandLine.Parameters(index = "0")
+    lateinit var org: String
+
+    @CommandLine.Parameters(index = "1")
+    lateinit var repo: String
+
+    @CommandLine.Parameters(index = "2")
+    lateinit var commit: String
+
+    @CommandLine.Parameters(index = "3")
+    lateinit var version: String
+
+    @CommandLine.Parameters(index = "4")
+    lateinit var templateFileLocation: String
+
+    @CommandLine.Parameters(index = "5")
+    lateinit var outputFileLocation: String
+
+    @CommandLine.Option(names = ["-p", "--tag-prefix"])
     var releaseTagPrefix: String? = null
-    val excludedPaths = mutableListOf<String>()
-    val includedPaths = mutableListOf<String>()
-    var nextAction: String? = null
-    args.drop(6).forEachIndexed { index, arg ->
-        if (nextAction == null) {
-            if (arg == "--include" || arg == "--exclude" || arg == "--tag-prefix") nextAction = arg
-            else throw RuntimeException("Invalid arg: $arg")
-        } else if (nextAction == "--include") {
-            includedPaths.add(arg)
-            nextAction = null
-        } else if (nextAction == "--exclude") {
-            excludedPaths.add(arg)
-            nextAction = null
-        } else {
-            if (releaseTagPrefix != null) throw RuntimeException("Cannot set --tag-prefix multiple times")
-            releaseTagPrefix = arg
-            nextAction = null
-        }
+
+    @CommandLine.Option(names = ["-e", "--exclude"])
+    var excludedPaths: List<String> = emptyList()
+
+    @CommandLine.Option(names = ["-i", "--include"])
+    var includedPaths: List<String> = emptyList()
+
+    @JvmStatic
+    fun main(args: Array<String>): Unit = exitProcess(CommandLine(NotesCreate).execute(*args))
+
+    override fun call(): Int {
+        val bazelWorkspaceDir = Paths.get(getEnv("BUILD_WORKSPACE_DIRECTORY"))
+        val githubToken = getEnv("NOTES_CREATE_TOKEN")
+
+        val templateFile = bazelWorkspaceDir.resolve(templateFileLocation)
+        if (templateFile.notExists()) throw RuntimeException("Template file '$templateFile' does not exist.")
+        val outputFile = bazelWorkspaceDir.resolve(outputFileLocation)
+
+        println("Commit: $org/$repo@$commit")
+        println("Version: $version")
+
+        val commits = collectCommits(org, repo, commit, Version.parse(version), bazelWorkspaceDir, githubToken, releaseTagPrefix, excludedPaths, includedPaths)
+        println("Found ${commits.size} commits to be collected into the release note.")
+        val notes = collectNotes(org, repo, commits.reversed(), githubToken)
+        writeNotesMd(notes, templateFile, outputFile, version)
+        return 0
     }
 
-    if (nextAction != null) throw RuntimeException("Missing input value for $nextAction")
-
-    val templateFile = bazelWorkspaceDir.resolve(templateFileLocation)
-    if (templateFile.notExists()) throw RuntimeException("Template file '$templateFile' does not exist.")
-    val outputFile = bazelWorkspaceDir.resolve(outputFileLocation)
-
-    println("Commit: $org/$repo@$commit")
-    println("Version: $version")
-
-    val commits = collectCommits(org, repo, commit, Version.parse(version), bazelWorkspaceDir, githubToken, releaseTagPrefix, excludedPaths, includedPaths)
-    println("Found ${commits.size} commits to be collected into the release note.")
-    val notes = collectNotes(org, repo, commits.reversed(), githubToken)
-    writeNotesMd(notes, templateFile, outputFile, version)
-}
-
-
-private fun writeNotesMd(notes: List<Note>, releaseTemplateFile: Path, releaseNotesFile: Path, version: String) {
-    val template = releaseTemplateFile.toFile().readText()
-    if (!template.matches(".*${Constant.releaseTemplateRegex.pattern}.*".toRegex(RegexOption.DOT_MATCHES_ALL)))
-        throw RuntimeException("The release-template does not contain the '${Constant.releaseTemplateRegex}' placeholder")
-    val markdown = template.replace(Constant.releaseTemplateRegex, escapeReplacement(Note.toMarkdown(notes)))
+    private fun writeNotesMd(notes: List<Note>, releaseTemplateFile: Path, releaseNotesFile: Path, version: String) {
+        val template = releaseTemplateFile.toFile().readText()
+        if (!template.matches(".*${Constant.releaseTemplateRegex.pattern}.*".toRegex(RegexOption.DOT_MATCHES_ALL)))
+            throw RuntimeException("The release-template does not contain the '${Constant.releaseTemplateRegex}' placeholder")
+        val markdown = template.replace(Constant.releaseTemplateRegex, escapeReplacement(Note.toMarkdown(notes)))
             .replace("{version}", version)
-    releaseNotesFile.toFile().writeText(markdown)
+        releaseNotesFile.toFile().writeText(markdown)
+    }
+
 }

--- a/tool/release/notes/NotesCreate.kt
+++ b/tool/release/notes/NotesCreate.kt
@@ -15,10 +15,32 @@ import kotlin.text.Regex.Companion.escapeReplacement
 fun main(args: Array<String>) {
     val bazelWorkspaceDir = Paths.get(getEnv("BUILD_WORKSPACE_DIRECTORY"))
     val githubToken = getEnv("NOTES_CREATE_TOKEN")
-    if (args.size != 6) throw RuntimeException("org, repo, commit, version, template, and output destination must be supplied")
+    if (args.size < 6) throw RuntimeException("org, repo, commit, version, template, and output destination must be supplied")
 
     operator fun <T> Array<T>.component6() = this[5]
     val (org, repo, commit, version, templateFileLocation, outputFileLocation) = args
+    var releaseTagPrefix: String? = null
+    val excludedPaths = mutableListOf<String>()
+    val includedPaths = mutableListOf<String>()
+    var nextAction: String? = null
+    args.drop(6).forEachIndexed { index, arg ->
+        if (nextAction == null) {
+            if (arg == "--include" || arg == "--exclude" || arg == "--tag-prefix") nextAction = arg
+            else throw RuntimeException("Invalid arg: $arg")
+        } else if (nextAction == "--include") {
+            includedPaths.add(arg)
+            nextAction = null
+        } else if (nextAction == "--exclude") {
+            excludedPaths.add(arg)
+            nextAction = null
+        } else {
+            if (releaseTagPrefix != null) throw RuntimeException("Cannot set --tag-prefix multiple times")
+            releaseTagPrefix = arg
+            nextAction = null
+        }
+    }
+
+    if (nextAction != null) throw RuntimeException("Missing input value for $nextAction")
 
     val templateFile = bazelWorkspaceDir.resolve(templateFileLocation)
     if (templateFile.notExists()) throw RuntimeException("Template file '$templateFile' does not exist.")
@@ -27,7 +49,7 @@ fun main(args: Array<String>) {
     println("Commit: $org/$repo@$commit")
     println("Version: $version")
 
-    val commits = collectCommits(org, repo, commit, Version.parse(version), bazelWorkspaceDir, githubToken)
+    val commits = collectCommits(org, repo, commit, Version.parse(version), bazelWorkspaceDir, githubToken, releaseTagPrefix, excludedPaths, includedPaths)
     println("Found ${commits.size} commits to be collected into the release note.")
     val notes = collectNotes(org, repo, commits.reversed(), githubToken)
     writeNotesMd(notes, templateFile, outputFile, version)


### PR DESCRIPTION
## Usage and product changes

Update the notes generation tool to respect a multi-product release setup (for example, that of https://github.com/typedb/typedb-tools)

- Support a `--release-tag-prefix`, to check the previous version of the correct product
- Support `--included-paths` and `--excluded-paths` to ignore irrelevant commits
  -  When collecting notes, commits that make changes in `--excluded-paths` without also making changes in `--included-paths` are skipped

## Motivation

Ensure that the release notes for our products make sense

## Implementation

- Support the new command line flags
- Get commit details to be able to inspect files
- Inspect files and skip commits accordingly during