### PR TITLE
Towards updating the tools to read commit/tag from git_override

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -364,8 +364,8 @@ bazel_dep(name = "rules_pkg", version = "1.0.1")
 bazel_dep(name = "typedb_bazel_distribution", version = "0.0.0")
 git_override(
     module_name = "typedb_bazel_distribution",
-    remote = "https://github.com/typedb/bazel-distribution",
-    commit = "dd811cf28715bbce8374e5e0f9defaf772e7dd36",
+    remote = "https://github.com/krishnangovindraj/bazel-distribution",
+    commit = "fbf533731be846d39160236b29c4b310ff08e740",
 )
 
 # ===========================================================

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -325,6 +325,104 @@
         ]
       }
     },
+    "@@protobuf+//python/dist:system_python.bzl%system_python_extension": {
+      "general": {
+        "bzlTransitiveDigest": "qh0n9IrXU/xS94wxKQrG1J63zrLkA1Wy2Y3BQxptPcI=",
+        "usagesDigest": "tCi55FyqtOJ2jXh9vcjrHCl4ov3kpWiwKl103nA9BOI=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "system_python": {
+            "repoRuleId": "@@protobuf+//python/dist:system_python.bzl%system_python",
+            "attributes": {
+              "minimum_python_version": "3.9"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": []
+      }
+    },
+    "@@pybind11_bazel+//:internal_configure.bzl%internal_configure_extension": {
+      "general": {
+        "bzlTransitiveDigest": "uxP2cZuW027Q8wpZbeJeuW5MXcNBO8GcOK/LNN2sPvQ=",
+        "usagesDigest": "D1r3lfzMuUBFxgG8V6o0bQTLMk3GkaGOaPzw53wrwyw=",
+        "recordedFileInputs": {
+          "@@pybind11_bazel+//MODULE.bazel": "e6f4c20442eaa7c90d7190d8dc539d0ab422f95c65a57cc59562170c58ae3d34"
+        },
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "pybind11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@pybind11_bazel+//:pybind11-BUILD.bazel",
+              "strip_prefix": "pybind11-2.12.0",
+              "urls": [
+                "https://github.com/pybind/pybind11/archive/v2.12.0.zip"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "pybind11_bazel+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_android+//bzlmod_extensions:apksig.bzl%apksig_extension": {
+      "general": {
+        "bzlTransitiveDigest": "xeN+uPP1PKslnv5h3+uyhGaFXC4IIzcFwX/nQHlNwZk=",
+        "usagesDigest": "zr/niBQ/s2fHozWAsg4vI70wAxcuFjG+QtM15qGkq9o=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "apksig": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://android.googlesource.com/platform/tools/apksig/+archive/24e3075e68ebe17c0b529bb24bfda819db5e2f3b.tar.gz",
+              "build_file": "@@rules_android+//bzlmod_extensions:apksig.BUILD"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_android+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_android+//bzlmod_extensions:com_android_dex.bzl%com_android_dex_extension": {
+      "general": {
+        "bzlTransitiveDigest": "2icqERrdWnpamgt/akEgAtfBsjNG1/st+AAFRZx9aH4=",
+        "usagesDigest": "c1Y/KGGjUYCyd8zNIVTUh1bynVXRFz6xGKaSCBpQANM=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "com_android_dex": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://android.googlesource.com/platform/dalvik/+archive/5a81c499a569731e2395f7c8d13c0e0d4e17a2b6.tar.gz",
+              "build_file": "@@rules_android+//bzlmod_extensions:com_android_dex.BUILD"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_android+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
     "@@rules_android+//rules/android_sdk_repository:rule.bzl%android_sdk_repository_extension": {
       "general": {
         "bzlTransitiveDigest": "+rMrzIrv7sImYmkbXJYv+gFpTJQ79X3MpwwMLI2A+oA=",
@@ -403,6 +501,2760 @@
             "rules_dotnet+",
             "bazel_tools",
             "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_dotnet+//dotnet:paket.paket2bazel_dependencies_extension.bzl%paket2bazel_dependencies_extension": {
+      "general": {
+        "bzlTransitiveDigest": "T/ODjgQMknoSIiSatcheY20h1v7xgVSlCkHCvarYWgo=",
+        "usagesDigest": "mL39UjUqNtEezZL+bUIfu+p8mLY0uBEV3cDZIFkyUrU=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "nuget.argu.v6.1.1": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "argu",
+              "version": "6.1.1",
+              "sha512": "sha512-ed1N3RMohnxS54MYuMgPz3766hXItY3L12IrPazZ+F8CXPKkxyV+p8xVkWmE5NDnRhEvaWptRhBrXstK9DhS/w=="
+            }
+          },
+          "nuget.chessie.v0.6.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "chessie",
+              "version": "0.6.0",
+              "sha512": "sha512-VUcf1SFTXQDf1ULVQ/IddKISCuVICj9OC+wW1LFSIDqpHfihP2M2CvLetBxsCvcplu8ugI4mo9ZV5gmdefHxPg=="
+            }
+          },
+          "nuget.fsharp.control.asyncseq.v3.2.1": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "fsharp.control.asyncseq",
+              "version": "3.2.1",
+              "sha512": "sha512-oV4Xx1MMOqpnZAon10bhN/JSUjwuc/H4hXq2SM7IWimfghk5yK85alZiqVH4momfGBKpr/RsBVfgCrqbmkaxJg=="
+            }
+          },
+          "nuget.fsharp.core.v6.0.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "fsharp.core",
+              "version": "6.0.3",
+              "sha512": "sha512-aDyKHiVFMwXWJrfW90iAeKyvw/lN+x98DPfx4oXke9Qnl4dz1sOi8KT2iczGeunqyWXh7nm+XUJ18i/0P3pZYw=="
+            }
+          },
+          "nuget.fsharp.systemtextjson.v0.16.6": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "fsharp.systemtextjson",
+              "version": "0.16.6",
+              "sha512": "sha512-7SoZOjo4dY6Ez47RSL5pWVAGiy8SPCzpjD4oBoGEkMNsnrRcy1WhD8jB2XyRufrboyBxKbGp7ZKMAQlDIc1Crg=="
+            }
+          },
+          "nuget.fsharpx.async.v1.14.1": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "fsharpx.async",
+              "version": "1.14.1",
+              "sha512": "sha512-8Ye/hgNHsnHWFtanfED+tgJJzPq4QEt+LUQ87Ie2JOiqb6WUP+vtF3WRBO2NIDqGQpivh207nwmCoFdK+T6jwQ=="
+            }
+          },
+          "nuget.fsharpx.collections.v2.1.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "fsharpx.collections",
+              "version": "2.1.3",
+              "sha512": "sha512-1KSJLhLpqOTPRKYkgi0YvPrvGybiYi642r53VrQb1U7LNd3VQNsh3z++v69ky8FEj4y+kP6NPbgZbFyJ8mumqA=="
+            }
+          },
+          "nuget.fsharpx.extras.v3.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "fsharpx.extras",
+              "version": "3.0.0",
+              "sha512": "sha512-7Wv7LF8hZfGG6KuXcQoGTnm6keDAtMwvI6S2lK90Z23Dvs44XGeRAGOsLRO3dg2k6atckdt6xd0SDqQ9FSa4vA=="
+            }
+          },
+          "nuget.microsoft.bcl.asyncinterfaces.v6.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "microsoft.bcl.asyncinterfaces",
+              "version": "6.0.0",
+              "sha512": "sha512-IhoFoMkQ96h7Yg2PODHtOStOuV0RK+4nTTXycAmtKiZEXenXzSNf5vtKA/JVCHS9o7493dlu2vnAhSqcI9ewmQ=="
+            }
+          },
+          "nuget.microsoft.csharp.v4.7.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "microsoft.csharp",
+              "version": "4.7.0",
+              "sha512": "sha512-LJaYhRX5VxTUuD9WUPGD3GpWTgs89SVfoOPvSEdt66tL3lQvny9sR/ZiC3px1qUV5EFebS44i2CBeiliHVaQ3w=="
+            }
+          },
+          "nuget.microsoft.extensions.fileproviders.abstractions.v8.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "microsoft.extensions.fileproviders.abstractions",
+              "version": "8.0.0",
+              "sha512": "sha512-/pqhjy6BlpTyDjIsk+B14nvuLVfd1TgGJPxIqVZpxSbCcKtcdPWMakch0Y7NtbL+vwMV+HlFha5lYXgxRZ4qCw=="
+            }
+          },
+          "nuget.microsoft.extensions.filesystemglobbing.v8.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "microsoft.extensions.filesystemglobbing",
+              "version": "8.0.0",
+              "sha512": "sha512-I6XlDPaVuhjHp398BQ5A1vsGWVdIDbF/XnXlzyacj1B2PJlsKNDc/KCeLBJIVAiYq1PEdMrccFVI9f5JHdJj/Q=="
+            }
+          },
+          "nuget.microsoft.extensions.primitives.v8.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "microsoft.extensions.primitives",
+              "version": "8.0.0",
+              "sha512": "sha512-H1R1yj084YRjRW3RNa+sUC1vgv6m5OSBSmH4ZhbDSN7PKLc9FcK7J20aPAOepgZPdeEyn286ZMqjUg1wq5LDLQ=="
+            }
+          },
+          "nuget.microsoft.netcore.app.ref.v6.0.5": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "microsoft.netcore.app.ref",
+              "version": "6.0.5",
+              "sha512": "sha512-quj/gyLoZLypJO7PwsZ8ib6ZSgFv1C9s5SJgwzl/gztynTJ/3oO/stA2gNMf0C33vTJ0J3SSF/kRPQ/ifY5xZg=="
+            }
+          },
+          "nuget.microsoft.netcore.platforms.v6.0.5": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "microsoft.netcore.platforms",
+              "version": "6.0.5",
+              "sha512": "sha512-GTMT/dgCRBCRUj11ssZ8K1FJm6Md+C/tSJl8I7YjxOFwSvopaIneV32y1VlnBTI4wy1SwueI7ou2sVfHkWENrA=="
+            }
+          },
+          "nuget.microsoft.netcore.targets.v5.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "microsoft.netcore.targets",
+              "version": "5.0.0",
+              "sha512": "sha512-hYHm3JAjQO/nySxcl1EpZhYEW+2P3H1eLZNr+QxgO5TnLS6hqtfi5WchjQzjid45MYmhy2X7IOmcWtDP4fpMGw=="
+            }
+          },
+          "nuget.microsoft.web.xdt.v3.1.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "microsoft.web.xdt",
+              "version": "3.1.0",
+              "sha512": "sha512-3VApgkdgOglJWtrXSgYzz6o8Cp6IpvmFQMeICyQvvbKoy+OjNwco5ovzBBL1HHj7kEgLfe2ruXW/ZQ1k+2YxYw=="
+            }
+          },
+          "nuget.microsoft.win32.systemevents.v6.0.1": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "microsoft.win32.systemevents",
+              "version": "6.0.1",
+              "sha512": "sha512-tCbvWn9ymrxUuAlYZCQ7eDwVSn7571UIeMYWizWCXPjQlESdfIGr1W6EXhrFm8BgPt2e9G5bJfxVrzx2knWR6A=="
+            }
+          },
+          "nuget.mono.cecil.v0.11.4": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "mono.cecil",
+              "version": "0.11.4",
+              "sha512": "sha512-CnjwUMmFHnScNG8e/4DRZQQX67H5ajekRDudmZ6Fy1jCLhyH1jjzbQCOEFhBLa2NjPWQpMF+RHdBJY8a7GgmlA=="
+            }
+          },
+          "nuget.netstandard.library.v2.0.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "netstandard.library",
+              "version": "2.0.3",
+              "sha512": "sha512-548M6mnBSJWxsIlkQHfbzoYxpiYFXZZSL00p4GHYv8PkiqFBnnT68mW5mGEsA/ch9fDO9GkPgkFQpWiXZN7mAQ=="
+            }
+          },
+          "nuget.newtonsoft.json.v13.0.1": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "newtonsoft.json",
+              "version": "13.0.1",
+              "sha512": "sha512-g3MbZi6vBTeaI/hEbvR7vBETSd1DWLe9i1E4P+nPY34v5i94zqUqDXvdWC3G+7tYN9SnsdU9zzegrnRz4h7nsQ=="
+            }
+          },
+          "nuget.nuget.commands.v6.7.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.commands",
+              "version": "6.7.0",
+              "sha512": "sha512-+fjzHcRYfT61xykFQfdAtRW5OMrqKRm2jwCPmGLWQn/uSGE9zEdKJD+HByWjV1EzJ/01FIYrKB94zg0ShDKjJQ=="
+            }
+          },
+          "nuget.nuget.common.v6.7.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.common",
+              "version": "6.7.0",
+              "sha512": "sha512-xxmTBZqBfMCaou4rJFKReYbTrfQXb4OfcT9QyVLN1nEe36KditRl0Uki0R03RVimNKeTzKjBUF6I4CZTAeu2YQ=="
+            }
+          },
+          "nuget.nuget.configuration.v6.7.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.configuration",
+              "version": "6.7.0",
+              "sha512": "sha512-MqkkKtRGH3Z73v1WylGpDMoUrVlNqoEFcaWE1Apudb6AWJYqGh4vyZUMdXsitoVpiakP3iiAMtprh4Gfa/Cv6Q=="
+            }
+          },
+          "nuget.nuget.credentials.v6.7.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.credentials",
+              "version": "6.7.0",
+              "sha512": "sha512-G5JCMbC24Cd0wFz7fZCXRKF5ZqWcm6UGwA3Y+nC9/pbV9sIkPKEsDYk6/QUBLIVnXbB3J1o5zgULa95QJ99bAg=="
+            }
+          },
+          "nuget.nuget.dependencyresolver.core.v6.7.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.dependencyresolver.core",
+              "version": "6.7.0",
+              "sha512": "sha512-8SGR7UF/A+tAgdTRIsh3v8qg47w9farAAXvHlbYylL+sFRIp36yGF0C1sXMuD/DEIl6GLc2M/UdawB+FpHg/tw=="
+            }
+          },
+          "nuget.nuget.frameworks.v6.7.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.frameworks",
+              "version": "6.7.0",
+              "sha512": "sha512-weGyDjVXp4LUKR9ZjMrtd38J6MkUC5xPU9hcGdksZBB0r+bJmKoZ5NJQAXLFbP3m5BhPLYIl3/aEmPlkCV25Og=="
+            }
+          },
+          "nuget.nuget.librarymodel.v6.7.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.librarymodel",
+              "version": "6.7.0",
+              "sha512": "sha512-YPHMmVII4QqjShzNUX61qg4u/j9mFhBD5iLDCnk8UgEmiWzQRLDFCvXCmbRoYznLJz2995sD7idtqWsvOh4YnA=="
+            }
+          },
+          "nuget.nuget.packagemanagement.v6.7.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.packagemanagement",
+              "version": "6.7.0",
+              "sha512": "sha512-QMP/PiheJgBQsP66XNmhdBqnpeyRmqfZjhsfAhjMgm8gfd2k6OGXb2LOV7hN6xbfbj9KrtMiwfzOvuZA6q27KQ=="
+            }
+          },
+          "nuget.nuget.packaging.v6.7.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.packaging",
+              "version": "6.7.0",
+              "sha512": "sha512-jEfG/a8hNhTDSWOadBi0nZRdTO+PXR98j4u6RnZ68Nyuw4LHviEXOG1kqZvraU3uYGssAoJatkFDYAM8kEX+WQ=="
+            }
+          },
+          "nuget.nuget.projectmodel.v6.7.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.projectmodel",
+              "version": "6.7.0",
+              "sha512": "sha512-BnheauzOjo1U/hCg0jyhflaNbffCbfZnquHc18+VneSANMB54Mg/xjHPLibx3R5zneQ6E3n0K50wtfRntrkH8g=="
+            }
+          },
+          "nuget.nuget.protocol.v6.7.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.protocol",
+              "version": "6.7.0",
+              "sha512": "sha512-/r+i3gmVYWa8KMETanGyaCqMPVLTwe8Gqza5khiDiETATeGEd+y7erJsy/pLwBpnl0/jSYpf+kxPq16xoiej6A=="
+            }
+          },
+          "nuget.nuget.resolver.v6.7.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.resolver",
+              "version": "6.7.0",
+              "sha512": "sha512-kLoXgmxb0dpzK5Dx1SiaTj2l0EXtU42HSMD9bQgjoc3BWi/5Fn6VvGe8Pd7U4firGmvxgkmmO0lJx6iF0dLLxQ=="
+            }
+          },
+          "nuget.nuget.versioning.v6.7.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.versioning",
+              "version": "6.7.0",
+              "sha512": "sha512-aZ0/Fd85juLKrg0rZw4rWJAFDuv0aW3SJj3fqwp5etkRZOwHO/11vmGh0eeMZ7gMAvnktvxax7h5Vaxkllv2ZA=="
+            }
+          },
+          "nuget.paket.core.v8.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "paket.core",
+              "version": "8.0.0",
+              "sha512": "sha512-Wn1E0lIbjitqogRA6sLRJLxKeIjqLLi5oeFClqGCwUBixPIZ58KM75NwtDAtbiyTqo7KdNBSoAuBI7z4P8lL5w=="
+            }
+          },
+          "nuget.runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-s9AMelYhmifrJqGjkRkqyoP7NMudky0vJPdYzjGKryWYhofREwzC4EesqYm+dooMQB++vbgvGrtrcZpU36Q+sA=="
+            }
+          },
+          "nuget.runtime.debian.9-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.debian.9-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-1kcSfJKTg00KxR43jsnYjjYTPoUh+f+OLpL4/yF/bzKikgxV6QPlz74UyrypYprz3NUHHOcsa12E7+Xp4RtTng=="
+            }
+          },
+          "nuget.runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-DPcJlXiNYg8lqqCAFTgaL9Yqs1brKG3H6b1XVimLf9RYxW7zOLujvf3HfTlvrYEWsAulgJ/+7Gh0mCw4FUt+IQ=="
+            }
+          },
+          "nuget.runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-2p9EjZTy8LkH/wx6OwRuk0ORuVL7PzqJ3cdvL/SY58Ep+XW0AYEBjyy7kloJ/nPZGYVUT+NS8kNwPU5ICV/DwQ=="
+            }
+          },
+          "nuget.runtime.fedora.27-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.fedora.27-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-2v5kHzEZgBFCz+5NJgZn3Dmi9gaYY/loR5PJEXvOJ018XIF6BmSGYNyHNXTmdFPq50EjwaGpHj8cQmR3z5oeGA=="
+            }
+          },
+          "nuget.runtime.fedora.28-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.fedora.28-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-qfB0WU/HXLYhTlXpDZi0eY1p1x9jlwxDlVFcWrj9u+2gFEesUKux9IoR9bzQLPPj//B0dSWolKEgW/1X70VWCA=="
+            }
+          },
+          "nuget.runtime.native.system.v4.3.1": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.native.system",
+              "version": "4.3.1",
+              "sha512": "sha512-AJsN0GLPijYtmFZdvPYnfTdAMTlvMttusjye6ZC1Edg5XUneNv1BCHzXfM0SWpqf+Gt/31WthibAPAorcN4F1g=="
+            }
+          },
+          "nuget.runtime.native.system.net.http.v4.3.1": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.native.system.net.http",
+              "version": "4.3.1",
+              "sha512": "sha512-n3clBjCv4nEoDl/hV4/DYwi/yoRrFZk9Tpe0TenLiITLHvtijO+OSYhwV7JmACcsZlLFKMaYW+P5yN3sK/xU0Q=="
+            }
+          },
+          "nuget.runtime.native.system.security.cryptography.apple.v4.3.1": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.native.system.security.cryptography.apple",
+              "version": "4.3.1",
+              "sha512": "sha512-C+AZUmQBFgXR/NxF80q0Sy7SgYiW+C3CcIuA7yd0f1FXWN16xhIRSmXN92IUSGx/ebGN3XmaeuVUZpd+NuY/jQ=="
+            }
+          },
+          "nuget.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-CiS94rEK+DWQJJbFqOc+SboSZQeswgRiao5QMZjHjhhRPi2NkawZZ0l99i8+eGNTVo6f4cYTOXVmNr0BeJTiYQ=="
+            }
+          },
+          "nuget.runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-kbvMwf5iS0oM7qiHPy3sHADQa2ncqFXVz7bQKCiPKcnNu5NTDz4cO/Nk4gy54iYjU0SSma/z2IfYIpPGVsdiZA=="
+            }
+          },
+          "nuget.runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-anMSS/nfTUvTuvUE3jg+sSEx7JUgLkeYS7T9dbb8ZE42XYWdaLJjRlp3qA/yYyoewJuVJ6ZPeI8w9QrlKgVSow=="
+            }
+          },
+          "nuget.runtime.opensuse.42.3-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.opensuse.42.3-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-KHQzsD6iTnD3Rpr+Odhe0II9LMwTJkIOMKekGzBz5TQlNbEpuc0LwQxMuCE4FZnzcefRYw3kDd5Xyu+AFND8FQ=="
+            }
+          },
+          "nuget.runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple.v4.3.1": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple",
+              "version": "4.3.1",
+              "sha512": "sha512-YVeP6XccbJen1k3sjfntjqWS+vAcVt37VW3eBuZvjH7ZlTmQz3t6n8gLNh342IeDSBM+06SPYtBqP1roAlIpDA=="
+            }
+          },
+          "nuget.runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-KBHT4RWCC3klyYzHWLweXSAPRzPLuzFdfixnzojA+tNUE6kHpyABhtbgTiwhGHyA3+TlyLOn1viw1NBoG7ZOxQ=="
+            }
+          },
+          "nuget.runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-Lmw34chaD1jDOrmiEl2jIXVoCfYhTFMWQWtC47RDRLKYpwLOjOkSa6E2LM5K28UNpkSOZu579Os/t+eZ+wAhOw=="
+            }
+          },
+          "nuget.runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-K6KLKN1ICpOqvVG2Dub+uX3gb/MqqiS1deVZpuj46M7ya9ranrGzFYVIMsQFI8f7vhc+sf0gyTtN0es9tN4jmw=="
+            }
+          },
+          "nuget.runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-IXiZH+OL4lP8dRKieebADFgWPgyq/vbMbYqXCz9EhfaU4CcRl1ygb3pmpNWhVJsVEV3fRb3tEaEFowmkb56WCQ=="
+            }
+          },
+          "nuget.runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-uOpq6ML3XC+QioF01mDpg6zuJEZs23+vjpbnOKQkZxyMSOGNanyleAjNgXLZyUo0NPa5c8QIMB878SvxLSxjhA=="
+            }
+          },
+          "nuget.runtime.ubuntu.18.04-x64.runtime.native.system.security.cryptography.openssl.v4.3.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "runtime.ubuntu.18.04-x64.runtime.native.system.security.cryptography.openssl",
+              "version": "4.3.3",
+              "sha512": "sha512-fefg8Dxuv7BKypFbd1HKIdO/x51l+NN4WP5GIqe+Gx6El1Aut7zZA5a9B8WPowDiGCwPIqEJaIhdwCjmbHqscQ=="
+            }
+          },
+          "nuget.system.collections.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.collections",
+              "version": "4.3.0",
+              "sha512": "sha512-ynuVLTDaFIfKTkOqUigXte4m5+EFNwYoEBEvxnp1EnZsOdQC85S7BCbREIu8+bu2Tpzh9a9zbvIVpRo15V8FGw=="
+            }
+          },
+          "nuget.system.collections.concurrent.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.collections.concurrent",
+              "version": "4.3.0",
+              "sha512": "sha512-NcGqPmNiFv5dwuvrUEKT5prWNV0m4iRTrwYK+U2CefqpO9z+EnrssLMWx+fZGFvKxy6ZSYTv238thRXx9Vz2gg=="
+            }
+          },
+          "nuget.system.componentmodel.composition.v6.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.componentmodel.composition",
+              "version": "6.0.0",
+              "sha512": "sha512-YWQ3ENu0D2st9ZV+Yj4u3IFcas0Pw7S4c7ymDUooPLb1psNJ53YniX2orSiY2OlRWnssaUsTytnVJa/KfCn5aA=="
+            }
+          },
+          "nuget.system.configuration.configurationmanager.v6.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.configuration.configurationmanager",
+              "version": "6.0.0",
+              "sha512": "sha512-3ljLko1jA6FjAf16qO2sN53+bEfm2AshZl+SurndX/UrPiRM9t8PlF8ccucckjN1YdvydS/DMkF0qMnsxwwyRw=="
+            }
+          },
+          "nuget.system.diagnostics.debug.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.diagnostics.debug",
+              "version": "4.3.0",
+              "sha512": "sha512-bFj+HjYY5/h2hMHOp+/H07Gb19+NJTX54ntixS9EHxG2eyEiXWvNYvQJ4CwqFiMcTbGb4zuPq1ubClyGYN2rJA=="
+            }
+          },
+          "nuget.system.diagnostics.diagnosticsource.v6.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.diagnostics.diagnosticsource",
+              "version": "6.0.0",
+              "sha512": "sha512-dYnmo66bitfHxLjNBU2LPp6Dn98n7hRyk7ZKGVzaAPw2MHy+40dLxfw7susxMkWfL3C//aJF+/UDAPgH2YhUZg=="
+            }
+          },
+          "nuget.system.diagnostics.tracing.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.diagnostics.tracing",
+              "version": "4.3.0",
+              "sha512": "sha512-0KXTDiYc1Ft9+rArf/vXa2TgybiS7YJuphSByYPAIIsFtpmBzXnpHNTlgR4c1MPOoGoa/OBYEezli+XkwgFp6g=="
+            }
+          },
+          "nuget.system.drawing.common.v6.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.drawing.common",
+              "version": "6.0.0",
+              "sha512": "sha512-1h8KPgHD6sFfE/wboEosfOTqyVZACy+qNh/sq9ODbUnVvTRPOYXuPZTNw/anK44H5CPNspZbT1yiIitd4ymI5A=="
+            }
+          },
+          "nuget.system.formats.asn1.v8.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.formats.asn1",
+              "version": "8.0.0",
+              "sha512": "sha512-KAcODhtEEDJs6494uw0/s/BxymRWD1yV4JHd0QOx8IV4B8JocCvk2mfOmmwVptBxydT25WJvOnzmh2vjoqbbwg=="
+            }
+          },
+          "nuget.system.globalization.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.globalization",
+              "version": "4.3.0",
+              "sha512": "sha512-gj0rowjLBztAoxRuzM0Nn9exYVrD+++xb3PYc+QR/YHDvch98gbT3H4vFMnNU6r8poSjVwwlRxKAqtqN6AXs4g=="
+            }
+          },
+          "nuget.system.globalization.calendars.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.globalization.calendars",
+              "version": "4.3.0",
+              "sha512": "sha512-6XGQIxQCs5N3S5Je/AKiv6QdHRF6F/uH2m45n1I0VGlidn6c2POZcO+kCOT0U80eZ1Giph42a8l0BuGwuKS+hg=="
+            }
+          },
+          "nuget.system.globalization.extensions.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.globalization.extensions",
+              "version": "4.3.0",
+              "sha512": "sha512-pNNgAD+V4MMe3znAuR4cc4UKYKxdADKxfbiIo8fXE0zvms2XIZ0UF0rSE7fARPSbNkzFcgBz6/y24b9uTsJM5Q=="
+            }
+          },
+          "nuget.system.io.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.io",
+              "version": "4.3.0",
+              "sha512": "sha512-v8paIePhmGuXZbE9xvvNb4uJ5ME4OFXR1+8la/G/L1GIl2nbU2WFnddgb79kVK3U2us7q1aZT/uY/R0D/ovB5g=="
+            }
+          },
+          "nuget.system.io.filesystem.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.io.filesystem",
+              "version": "4.3.0",
+              "sha512": "sha512-T7WB1vhblSmgkaDpdGM3Uqo55Qsr5sip5eyowrwiXOoHBkzOx3ePd9+Zh97r9NzOwFCxqX7awO6RBxQuao7n7g=="
+            }
+          },
+          "nuget.system.io.filesystem.primitives.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.io.filesystem.primitives",
+              "version": "4.3.0",
+              "sha512": "sha512-WIWVPQlYLP/Zc9I6IakpBk1y8ryVGK83MtZx//zGKKi2hvHQWKAB7moRQCOz5Is/wNDksiYpocf3FeA3le6e5Q=="
+            }
+          },
+          "nuget.system.linq.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.linq",
+              "version": "4.3.0",
+              "sha512": "sha512-6sx/4exSb0BfW6DmcfYW0OW+nBgo1UOp4vjGXfQJnWsupKn6LNrk80sXDcNxQvYOJn4TfKOfNQKB7XDS3GIEWA=="
+            }
+          },
+          "nuget.system.net.http.v4.3.4": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.net.http",
+              "version": "4.3.4",
+              "sha512": "sha512-Fj7e73NNHwof97gFPTJuq8gv6G895yxkZt14DVnZdEh4gvKl8WrksCwNjIp/JeYX/yu/qxM/iOv9ai+ZY3Fp7Q=="
+            }
+          },
+          "nuget.system.net.http.winhttphandler.v6.0.1": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.net.http.winhttphandler",
+              "version": "6.0.1",
+              "sha512": "sha512-uLH7CWm9PZaO0SNhnEL8wvLCwcLCjC9M/jWgl7kTwp5PuFCfeCn7hrq6c0Bpfq2s1SCkx9lNUoRWnM76wMpnxQ=="
+            }
+          },
+          "nuget.system.net.primitives.v4.3.1": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.net.primitives",
+              "version": "4.3.1",
+              "sha512": "sha512-BgdlyYCI7rrdh36p3lMTqbkvaafPETpB1bk9iQlFdQxYE692kiXvmseXs8ghL+gEgQF2xgDc8GH4QLkSgUUs+Q=="
+            }
+          },
+          "nuget.system.reflection.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.reflection",
+              "version": "4.3.0",
+              "sha512": "sha512-IyW2ftYNzgMCgHBk8lQiy+G3+ydbU5tE+6PEqM5JJvIdeFKaXDSzHAPYDREPe6zpr5WJ1Fcma+rAFCIAV6+DMw=="
+            }
+          },
+          "nuget.system.reflection.emit.lightweight.v4.7.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.reflection.emit.lightweight",
+              "version": "4.7.0",
+              "sha512": "sha512-Blr1A9Vqk+ZUknlk6sFrhOcpuqx4bp7kqwZfhwkmmhz+9dgOl8cZ9CnSXbalbL9rfHmi5HDFydxQsfozl2PvjQ=="
+            }
+          },
+          "nuget.system.reflection.primitives.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.reflection.primitives",
+              "version": "4.3.0",
+              "sha512": "sha512-1LnMkF9aXKuQAgYzjoiQaL9mwY7oY6KdaO/zzeLMynNBEqKoUfLi5TiKIewoAF+hkxfGTZsjkjsF1jRL4uSeqg=="
+            }
+          },
+          "nuget.system.resources.resourcemanager.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.resources.resourcemanager",
+              "version": "4.3.0",
+              "sha512": "sha512-kGfbKPHEjQj8Uq1Apgj4jBStkRJkZ0Hdr0Jv3+aL7WGrAZVLF5Rh5h0Yc3FgDB5uXDbHiJk/WhBaZPVwKmuB1A=="
+            }
+          },
+          "nuget.system.runtime.v4.3.1": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.runtime",
+              "version": "4.3.1",
+              "sha512": "sha512-Al69mPDfzdD+bKGK2HAfB+lNFOHFqnkqzNnUJmmvUe1/qEPK9M7EiTT4zuycKDPy7ev11xz8XVgJWKP0hm7NIA=="
+            }
+          },
+          "nuget.system.runtime.compilerservices.unsafe.v6.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.runtime.compilerservices.unsafe",
+              "version": "6.0.0",
+              "sha512": "sha512-1AVzAb5OxJNvJLnOADtexNmWgattm2XVOT3TjQTN7Dd4SqoSwai1CsN2fth42uQldJSQdz/sAec0+TzxBFgisw=="
+            }
+          },
+          "nuget.system.runtime.extensions.v4.3.1": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.runtime.extensions",
+              "version": "4.3.1",
+              "sha512": "sha512-VSbBNw3UQxuHk4aALPsYo154l+TKUR4Ij+Nj9GPnyJkzAmMewY1AyHXuaE+KCJ6JBj2SoO4uwLqY4ORKW9JRTw=="
+            }
+          },
+          "nuget.system.runtime.handles.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.runtime.handles",
+              "version": "4.3.0",
+              "sha512": "sha512-CluvHdVUv54BvLTOCCyybugreDNk/rR8unMPruzXDtxSjvrQOU3M4R831/lQf4YI8VYp668FGQa/01E+Rq8PEQ=="
+            }
+          },
+          "nuget.system.runtime.interopservices.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.runtime.interopservices",
+              "version": "4.3.0",
+              "sha512": "sha512-ZQeZw+ZU77ua1nFXycYM5G8oioFZe+N84qC/XUg1BEBl7z9luZcyjLu7+4H0yJuNfn1hOAiAAZ3u5us/lj9w2Q=="
+            }
+          },
+          "nuget.system.runtime.numerics.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.runtime.numerics",
+              "version": "4.3.0",
+              "sha512": "sha512-PjR/qo5+xITUgeU7HCGf4c40augniiFLRQjPDiM8Fie9nGxsfGVOjB9BQycYON3ZWT9joQQ1d62HxA45Kvf9NA=="
+            }
+          },
+          "nuget.system.security.accesscontrol.v6.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.accesscontrol",
+              "version": "6.0.0",
+              "sha512": "sha512-ZKNqEDuVSrS36KdsDodleb1ITDCOREwtkV+5oP0FrWNhRQHtI1xUSvybQxy4pM8PBxW47UFOhZWObWhXkWj7RQ=="
+            }
+          },
+          "nuget.system.security.cryptography.algorithms.v4.3.1": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.cryptography.algorithms",
+              "version": "4.3.1",
+              "sha512": "sha512-NLArYLaaVOExC1EVEuMhCkm/sFhMUPgLWcWG1xgK2XPjtUGfelV4ODeIQ5VGDbPg2xPI+yfebRcLjS2rHJCtzw=="
+            }
+          },
+          "nuget.system.security.cryptography.cng.v5.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.cryptography.cng",
+              "version": "5.0.0",
+              "sha512": "sha512-trvkAklUhzM+/z9bPnGmDLzmbvD0l1IlC6gpFRpzjGLylTgtTPqm8Uv7tnDBTuBQObjEZBxNS0bChIi6zQCV9w=="
+            }
+          },
+          "nuget.system.security.cryptography.csp.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.cryptography.csp",
+              "version": "4.3.0",
+              "sha512": "sha512-QzF1kXR6GPUvaDGH4Jrf4OA1c+baxDC/O6E/RAzbHHux+SBTadXzsqDz/flgTVuh5tlKiZol0sUz5FMzhXjzUQ=="
+            }
+          },
+          "nuget.system.security.cryptography.encoding.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.cryptography.encoding",
+              "version": "4.3.0",
+              "sha512": "sha512-XCat0j5jVC83UG9fofcuiYDwN0PVKc2OWD0QVLjYpXn7dz+gNaANkHPbhNtr5PR8rDQNHrxtI912Hb29YAB14A=="
+            }
+          },
+          "nuget.system.security.cryptography.openssl.v5.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.cryptography.openssl",
+              "version": "5.0.0",
+              "sha512": "sha512-+8P4Eo9HMcke1V4bPK6JjBaHilI5MAYLcqPKVHcpbJmW3O6qOCxutBmEiuT3e6CZvk8cE4v2wqC5J3woxqEF/Q=="
+            }
+          },
+          "nuget.system.security.cryptography.pkcs.v8.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.cryptography.pkcs",
+              "version": "8.0.0",
+              "sha512": "sha512-zWk9gw+KSXYnBfrm+nUF7u17gexrNmJOwj0WcLw7kxJB9VAabPTsj9PwPod8QIkSp0q4M/4DTHKhMbc7op2GlQ=="
+            }
+          },
+          "nuget.system.security.cryptography.primitives.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.cryptography.primitives",
+              "version": "4.3.0",
+              "sha512": "sha512-WtgnP5mOu5zKL3vQMUPT9tV7XVYGV7Jtb0540DgBD7MMN5ojonwIcw8VybZvS6VloGmE7CRt/Hms8adBsN1DRw=="
+            }
+          },
+          "nuget.system.security.cryptography.protecteddata.v6.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.cryptography.protecteddata",
+              "version": "6.0.0",
+              "sha512": "sha512-SJtdqwq/rfuLwtBDfeg6FEeRgHGUlEDnZttwHIHDUY3mo4o+D2mXBrBtWRq1OTx7wLLqqBwVv/FWM5JI5sNXMA=="
+            }
+          },
+          "nuget.system.security.cryptography.x509certificates.v4.3.2": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.cryptography.x509certificates",
+              "version": "4.3.2",
+              "sha512": "sha512-Ax8SNsw9NCe5pBEysVjrPiGgmcw9ToUMQyNOsbKL0BAGO3VQ+Gis2eleJ7KVmJ5j2gFdgh42yc9U2hboXdy+3A=="
+            }
+          },
+          "nuget.system.security.permissions.v6.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.permissions",
+              "version": "6.0.0",
+              "sha512": "sha512-1PIXLMOxZPEE+i46Mwti8qFfUOBQqRZZ21co8o1NXWyoZg7sOk+SIJAYGlS8Hp9mNMpJdQOYNgcn0bxZ22ICeA=="
+            }
+          },
+          "nuget.system.text.encoding.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.text.encoding",
+              "version": "4.3.0",
+              "sha512": "sha512-b/f+7HMTpxIfeV7H03bkuHKMFylCGfr9/U6gePnfFFW0aF8LOWLDgQCY6V1oWUqDksC3mdNuyChM1vy9TP4sZw=="
+            }
+          },
+          "nuget.system.text.json.v5.0.2": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.text.json",
+              "version": "5.0.2",
+              "sha512": "sha512-PTL4h2MLbKEqZ/9TE6SEmJp1txIh0GjzYPQrWGbfJ5sgbPrpXzb9sOoXe3cid51zDBE+2KCLd95e/04JiNr0TQ=="
+            }
+          },
+          "nuget.system.threading.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.threading",
+              "version": "4.3.0",
+              "sha512": "sha512-l6J1G9zmn6r5xU+DSp/Vxgx6eG+qUvQgdpgo28m1gEwfNyG6HqlF6h2ESDXZCYEPnngsmkTQ+q7MyyMMTNlaiA=="
+            }
+          },
+          "nuget.system.threading.tasks.v4.3.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.threading.tasks",
+              "version": "4.3.0",
+              "sha512": "sha512-fUiP+CyyCjs872OA8trl6p97qma/da1xGq3h4zAbJZk8zyaU4zyEfqW5vbkP80xG/Nimun1vlWBboMEk7XxdEw=="
+            }
+          },
+          "nuget.system.windows.extensions.v6.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.windows.extensions",
+              "version": "6.0.0",
+              "sha512": "sha512-9R7sgWb5e1/OokgW7HN8JNXFpcsUXvLTMnfJoWBE9AvD+5e0z+f5ojr3BO3pFYbGq9Ks8AsndTi7ME13ocpU8A=="
+            }
+          },
+          "paket.paket2bazel_dependencies": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_repo.bzl%_nuget_repo",
+            "attributes": {
+              "repo_name": "paket.paket2bazel_dependencies",
+              "packages": [
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"net462\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"net47\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"net471\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"net472\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"net48\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"net5.0\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"net6.0\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"net7.0\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"net8.0\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"netcoreapp2.1\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"netcoreapp2.2\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"netcoreapp3.0\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"netcoreapp3.1\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"],\"netstandard2.1\":[\"FSharp.Core\",\"System.Configuration.ConfigurationManager\"]},\"framework_list\":[],\"id\":\"Argu\",\"sha512\":\"sha512-ed1N3RMohnxS54MYuMgPz3766hXItY3L12IrPazZ+F8CXPKkxyV+p8xVkWmE5NDnRhEvaWptRhBrXstK9DhS/w==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.1.1\"}",
+                "{\"dependencies\":{\"net11\":[\"FSharp.Core\"],\"net20\":[\"FSharp.Core\"],\"net30\":[\"FSharp.Core\"],\"net35\":[\"FSharp.Core\"],\"net40\":[\"FSharp.Core\"],\"net403\":[\"FSharp.Core\"],\"net45\":[\"FSharp.Core\"],\"net451\":[\"FSharp.Core\"],\"net452\":[\"FSharp.Core\"],\"net46\":[\"FSharp.Core\"],\"net461\":[\"NETStandard.Library\",\"FSharp.Core\"],\"net462\":[\"NETStandard.Library\",\"FSharp.Core\"],\"net47\":[\"NETStandard.Library\",\"FSharp.Core\"],\"net471\":[\"NETStandard.Library\",\"FSharp.Core\"],\"net472\":[\"NETStandard.Library\",\"FSharp.Core\"],\"net48\":[\"NETStandard.Library\",\"FSharp.Core\"],\"net5.0\":[\"NETStandard.Library\",\"FSharp.Core\"],\"net6.0\":[\"NETStandard.Library\",\"FSharp.Core\"],\"net7.0\":[\"NETStandard.Library\",\"FSharp.Core\"],\"net8.0\":[\"NETStandard.Library\",\"FSharp.Core\"],\"netcoreapp1.0\":[\"NETStandard.Library\",\"FSharp.Core\"],\"netcoreapp1.1\":[\"NETStandard.Library\",\"FSharp.Core\"],\"netcoreapp2.0\":[\"NETStandard.Library\",\"FSharp.Core\"],\"netcoreapp2.1\":[\"NETStandard.Library\",\"FSharp.Core\"],\"netcoreapp2.2\":[\"NETStandard.Library\",\"FSharp.Core\"],\"netcoreapp3.0\":[\"NETStandard.Library\",\"FSharp.Core\"],\"netcoreapp3.1\":[\"NETStandard.Library\",\"FSharp.Core\"],\"netstandard\":[\"FSharp.Core\"],\"netstandard1.0\":[\"FSharp.Core\"],\"netstandard1.1\":[\"FSharp.Core\"],\"netstandard1.2\":[\"FSharp.Core\"],\"netstandard1.3\":[\"FSharp.Core\"],\"netstandard1.4\":[\"FSharp.Core\"],\"netstandard1.5\":[\"FSharp.Core\"],\"netstandard1.6\":[\"NETStandard.Library\",\"FSharp.Core\"],\"netstandard2.0\":[\"NETStandard.Library\",\"FSharp.Core\"],\"netstandard2.1\":[\"NETStandard.Library\",\"FSharp.Core\"]},\"framework_list\":[],\"id\":\"Chessie\",\"sha512\":\"sha512-VUcf1SFTXQDf1ULVQ/IddKISCuVICj9OC+wW1LFSIDqpHfihP2M2CvLetBxsCvcplu8ugI4mo9ZV5gmdefHxPg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"0.6.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"FSharp.Core\",\"Microsoft.Bcl.AsyncInterfaces\"],\"net462\":[\"FSharp.Core\",\"Microsoft.Bcl.AsyncInterfaces\"],\"net47\":[\"FSharp.Core\",\"Microsoft.Bcl.AsyncInterfaces\"],\"net471\":[\"FSharp.Core\",\"Microsoft.Bcl.AsyncInterfaces\"],\"net472\":[\"FSharp.Core\",\"Microsoft.Bcl.AsyncInterfaces\"],\"net48\":[\"FSharp.Core\",\"Microsoft.Bcl.AsyncInterfaces\"],\"net5.0\":[\"FSharp.Core\",\"Microsoft.Bcl.AsyncInterfaces\"],\"net6.0\":[\"FSharp.Core\",\"Microsoft.Bcl.AsyncInterfaces\"],\"net7.0\":[\"FSharp.Core\",\"Microsoft.Bcl.AsyncInterfaces\"],\"net8.0\":[\"FSharp.Core\",\"Microsoft.Bcl.AsyncInterfaces\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"FSharp.Core\",\"Microsoft.Bcl.AsyncInterfaces\"],\"netcoreapp2.1\":[\"FSharp.Core\",\"Microsoft.Bcl.AsyncInterfaces\"],\"netcoreapp2.2\":[\"FSharp.Core\",\"Microsoft.Bcl.AsyncInterfaces\"],\"netcoreapp3.0\":[\"FSharp.Core\",\"Microsoft.Bcl.AsyncInterfaces\"],\"netcoreapp3.1\":[\"FSharp.Core\",\"Microsoft.Bcl.AsyncInterfaces\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"FSharp.Core\",\"Microsoft.Bcl.AsyncInterfaces\"],\"netstandard2.1\":[\"FSharp.Core\",\"Microsoft.Bcl.AsyncInterfaces\"]},\"framework_list\":[],\"id\":\"FSharp.Control.AsyncSeq\",\"sha512\":\"sha512-oV4Xx1MMOqpnZAon10bhN/JSUjwuc/H4hXq2SM7IWimfghk5yK85alZiqVH4momfGBKpr/RsBVfgCrqbmkaxJg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"3.2.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"FSharp.Core\",\"sha512\":\"sha512-aDyKHiVFMwXWJrfW90iAeKyvw/lN+x98DPfx4oXke9Qnl4dz1sOi8KT2iczGeunqyWXh7nm+XUJ18i/0P3pZYw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"FSharp.Core\",\"System.Text.Json\"],\"net462\":[\"FSharp.Core\",\"System.Text.Json\"],\"net47\":[\"FSharp.Core\",\"System.Text.Json\"],\"net471\":[\"FSharp.Core\",\"System.Text.Json\"],\"net472\":[\"FSharp.Core\",\"System.Text.Json\"],\"net48\":[\"FSharp.Core\",\"System.Text.Json\"],\"net5.0\":[\"FSharp.Core\",\"System.Text.Json\"],\"net6.0\":[\"FSharp.Core\",\"System.Text.Json\"],\"net7.0\":[\"FSharp.Core\",\"System.Text.Json\"],\"net8.0\":[\"FSharp.Core\",\"System.Text.Json\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"FSharp.Core\",\"System.Text.Json\"],\"netcoreapp2.1\":[\"FSharp.Core\",\"System.Text.Json\"],\"netcoreapp2.2\":[\"FSharp.Core\",\"System.Text.Json\"],\"netcoreapp3.0\":[\"FSharp.Core\",\"System.Text.Json\"],\"netcoreapp3.1\":[\"FSharp.Core\",\"System.Text.Json\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"FSharp.Core\",\"System.Text.Json\"],\"netstandard2.1\":[\"FSharp.Core\",\"System.Text.Json\"]},\"framework_list\":[],\"id\":\"FSharp.SystemTextJson\",\"sha512\":\"sha512-7SoZOjo4dY6Ez47RSL5pWVAGiy8SPCzpjD4oBoGEkMNsnrRcy1WhD8jB2XyRufrboyBxKbGp7ZKMAQlDIc1Crg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"0.16.6\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"],\"net46\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"],\"net461\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"],\"net462\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"],\"net47\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"],\"net471\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"],\"net472\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"],\"net48\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"],\"net5.0\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"],\"net6.0\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"],\"net7.0\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"],\"net8.0\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"],\"netcoreapp2.1\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"],\"netcoreapp2.2\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"],\"netcoreapp3.0\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"],\"netcoreapp3.1\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"],\"netstandard2.1\":[\"FSharp.Control.AsyncSeq\",\"FSharp.Core\"]},\"framework_list\":[],\"id\":\"FSharpx.Async\",\"sha512\":\"sha512-8Ye/hgNHsnHWFtanfED+tgJJzPq4QEt+LUQ87Ie2JOiqb6WUP+vtF3WRBO2NIDqGQpivh207nwmCoFdK+T6jwQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"1.14.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[\"FSharp.Core\"],\"net451\":[\"FSharp.Core\"],\"net452\":[\"FSharp.Core\"],\"net46\":[\"FSharp.Core\"],\"net461\":[\"FSharp.Core\"],\"net462\":[\"FSharp.Core\"],\"net47\":[\"FSharp.Core\"],\"net471\":[\"FSharp.Core\"],\"net472\":[\"FSharp.Core\"],\"net48\":[\"FSharp.Core\"],\"net5.0\":[\"FSharp.Core\"],\"net6.0\":[\"FSharp.Core\"],\"net7.0\":[\"FSharp.Core\"],\"net8.0\":[\"FSharp.Core\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"FSharp.Core\"],\"netcoreapp2.1\":[\"FSharp.Core\"],\"netcoreapp2.2\":[\"FSharp.Core\"],\"netcoreapp3.0\":[\"FSharp.Core\"],\"netcoreapp3.1\":[\"FSharp.Core\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"FSharp.Core\"],\"netstandard2.1\":[\"FSharp.Core\"]},\"framework_list\":[],\"id\":\"FSharpx.Collections\",\"sha512\":\"sha512-1KSJLhLpqOTPRKYkgi0YvPrvGybiYi642r53VrQb1U7LNd3VQNsh3z++v69ky8FEj4y+kP6NPbgZbFyJ8mumqA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"2.1.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"],\"net46\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"],\"net461\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"],\"net462\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"],\"net47\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"],\"net471\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"],\"net472\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"],\"net48\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"],\"net5.0\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"],\"net6.0\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"],\"net7.0\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"],\"net8.0\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"],\"netcoreapp2.1\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"],\"netcoreapp2.2\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"],\"netcoreapp3.0\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"],\"netcoreapp3.1\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"],\"netstandard2.1\":[\"FSharp.Core\",\"FSharpx.Async\",\"FSharpx.Collections\",\"System.Reflection.Emit.Lightweight\"]},\"framework_list\":[],\"id\":\"FSharpx.Extras\",\"sha512\":\"sha512-7Wv7LF8hZfGG6KuXcQoGTnm6keDAtMwvI6S2lK90Z23Dvs44XGeRAGOsLRO3dg2k6atckdt6xd0SDqQ9FSa4vA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"3.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Microsoft.Bcl.AsyncInterfaces\",\"sha512\":\"sha512-IhoFoMkQ96h7Yg2PODHtOStOuV0RK+4nTTXycAmtKiZEXenXzSNf5vtKA/JVCHS9o7493dlu2vnAhSqcI9ewmQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[\"NETStandard.Library\"],\"netcoreapp1.1\":[\"NETStandard.Library\"],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[\"NETStandard.Library\"],\"netstandard1.1\":[\"NETStandard.Library\"],\"netstandard1.2\":[\"NETStandard.Library\"],\"netstandard1.3\":[\"NETStandard.Library\"],\"netstandard1.4\":[\"NETStandard.Library\"],\"netstandard1.5\":[\"NETStandard.Library\"],\"netstandard1.6\":[\"NETStandard.Library\"],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Microsoft.CSharp\",\"sha512\":\"sha512-LJaYhRX5VxTUuD9WUPGD3GpWTgs89SVfoOPvSEdt66tL3lQvny9sR/ZiC3px1qUV5EFebS44i2CBeiliHVaQ3w==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.7.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"Microsoft.Extensions.Primitives\"],\"net462\":[\"Microsoft.Extensions.Primitives\"],\"net47\":[\"Microsoft.Extensions.Primitives\"],\"net471\":[\"Microsoft.Extensions.Primitives\"],\"net472\":[\"Microsoft.Extensions.Primitives\"],\"net48\":[\"Microsoft.Extensions.Primitives\"],\"net5.0\":[\"Microsoft.Extensions.Primitives\"],\"net6.0\":[\"Microsoft.Extensions.Primitives\"],\"net7.0\":[\"Microsoft.Extensions.Primitives\"],\"net8.0\":[\"Microsoft.Extensions.Primitives\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"Microsoft.Extensions.Primitives\"],\"netcoreapp2.1\":[\"Microsoft.Extensions.Primitives\"],\"netcoreapp2.2\":[\"Microsoft.Extensions.Primitives\"],\"netcoreapp3.0\":[\"Microsoft.Extensions.Primitives\"],\"netcoreapp3.1\":[\"Microsoft.Extensions.Primitives\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"Microsoft.Extensions.Primitives\"],\"netstandard2.1\":[\"Microsoft.Extensions.Primitives\"]},\"framework_list\":[],\"id\":\"Microsoft.Extensions.FileProviders.Abstractions\",\"sha512\":\"sha512-/pqhjy6BlpTyDjIsk+B14nvuLVfd1TgGJPxIqVZpxSbCcKtcdPWMakch0Y7NtbL+vwMV+HlFha5lYXgxRZ4qCw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"8.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Microsoft.Extensions.FileSystemGlobbing\",\"sha512\":\"sha512-I6XlDPaVuhjHp398BQ5A1vsGWVdIDbF/XnXlzyacj1B2PJlsKNDc/KCeLBJIVAiYq1PEdMrccFVI9f5JHdJj/Q==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"8.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net462\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net47\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net471\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net472\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net48\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net5.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net6.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp2.1\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp2.2\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp3.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp3.1\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netstandard2.1\":[\"System.Runtime.CompilerServices.Unsafe\"]},\"framework_list\":[],\"id\":\"Microsoft.Extensions.Primitives\",\"sha512\":\"sha512-H1R1yj084YRjRW3RNa+sUC1vgv6m5OSBSmH4ZhbDSN7PKLc9FcK7J20aPAOepgZPdeEyn286ZMqjUg1wq5LDLQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"8.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[\"Microsoft.CSharp|6.0.0.0\",\"Microsoft.VisualBasic.Core|11.0.0.0\",\"Microsoft.VisualBasic|10.0.0.0\",\"Microsoft.Win32.Primitives|6.0.0.0\",\"Microsoft.Win32.Registry|6.0.0.0\",\"System.AppContext|6.0.0.0\",\"System.Buffers|6.0.0.0\",\"System.Collections.Concurrent|6.0.0.0\",\"System.Collections.Immutable|6.0.0.0\",\"System.Collections.NonGeneric|6.0.0.0\",\"System.Collections.Specialized|6.0.0.0\",\"System.Collections|6.0.0.0\",\"System.ComponentModel.Annotations|6.0.0.0\",\"System.ComponentModel.DataAnnotations|4.0.0.0\",\"System.ComponentModel.EventBasedAsync|6.0.0.0\",\"System.ComponentModel.Primitives|6.0.0.0\",\"System.ComponentModel.TypeConverter|6.0.0.0\",\"System.ComponentModel|6.0.0.0\",\"System.Configuration|4.0.0.0\",\"System.Console|6.0.0.0\",\"System.Core|4.0.0.0\",\"System.Data.Common|6.0.0.0\",\"System.Data.DataSetExtensions|4.0.0.0\",\"System.Data|4.0.0.0\",\"System.Diagnostics.Contracts|6.0.0.0\",\"System.Diagnostics.Debug|6.0.0.0\",\"System.Diagnostics.DiagnosticSource|6.0.0.0\",\"System.Diagnostics.FileVersionInfo|6.0.0.0\",\"System.Diagnostics.Process|6.0.0.0\",\"System.Diagnostics.StackTrace|6.0.0.0\",\"System.Diagnostics.TextWriterTraceListener|6.0.0.0\",\"System.Diagnostics.Tools|6.0.0.0\",\"System.Diagnostics.TraceSource|6.0.0.0\",\"System.Diagnostics.Tracing|6.0.0.0\",\"System.Drawing.Primitives|6.0.0.0\",\"System.Drawing|4.0.0.0\",\"System.Dynamic.Runtime|6.0.0.0\",\"System.Formats.Asn1|6.0.0.0\",\"System.Globalization.Calendars|6.0.0.0\",\"System.Globalization.Extensions|6.0.0.0\",\"System.Globalization|6.0.0.0\",\"System.IO.Compression.Brotli|6.0.0.0\",\"System.IO.Compression.FileSystem|4.0.0.0\",\"System.IO.Compression.ZipFile|6.0.0.0\",\"System.IO.Compression|6.0.0.0\",\"System.IO.FileSystem.AccessControl|6.0.0.0\",\"System.IO.FileSystem.DriveInfo|6.0.0.0\",\"System.IO.FileSystem.Primitives|6.0.0.0\",\"System.IO.FileSystem.Watcher|6.0.0.0\",\"System.IO.FileSystem|6.0.0.0\",\"System.IO.IsolatedStorage|6.0.0.0\",\"System.IO.MemoryMappedFiles|6.0.0.0\",\"System.IO.Pipes.AccessControl|6.0.0.0\",\"System.IO.Pipes|6.0.0.0\",\"System.IO.UnmanagedMemoryStream|6.0.0.0\",\"System.IO|6.0.0.0\",\"System.Linq.Expressions|6.0.0.0\",\"System.Linq.Parallel|6.0.0.0\",\"System.Linq.Queryable|6.0.0.0\",\"System.Linq|6.0.0.0\",\"System.Memory|6.0.0.0\",\"System.Net.Http.Json|6.0.0.0\",\"System.Net.Http|6.0.0.0\",\"System.Net.HttpListener|6.0.0.0\",\"System.Net.Mail|6.0.0.0\",\"System.Net.NameResolution|6.0.0.0\",\"System.Net.NetworkInformation|6.0.0.0\",\"System.Net.Ping|6.0.0.0\",\"System.Net.Primitives|6.0.0.0\",\"System.Net.Requests|6.0.0.0\",\"System.Net.Security|6.0.0.0\",\"System.Net.ServicePoint|6.0.0.0\",\"System.Net.Sockets|6.0.0.0\",\"System.Net.WebClient|6.0.0.0\",\"System.Net.WebHeaderCollection|6.0.0.0\",\"System.Net.WebProxy|6.0.0.0\",\"System.Net.WebSockets.Client|6.0.0.0\",\"System.Net.WebSockets|6.0.0.0\",\"System.Net|4.0.0.0\",\"System.Numerics.Vectors|6.0.0.0\",\"System.Numerics|4.0.0.0\",\"System.ObjectModel|6.0.0.0\",\"System.Reflection.DispatchProxy|6.0.0.0\",\"System.Reflection.Emit.ILGeneration|6.0.0.0\",\"System.Reflection.Emit.Lightweight|6.0.0.0\",\"System.Reflection.Emit|6.0.0.0\",\"System.Reflection.Extensions|6.0.0.0\",\"System.Reflection.Metadata|6.0.0.0\",\"System.Reflection.Primitives|6.0.0.0\",\"System.Reflection.TypeExtensions|6.0.0.0\",\"System.Reflection|6.0.0.0\",\"System.Resources.Reader|6.0.0.0\",\"System.Resources.ResourceManager|6.0.0.0\",\"System.Resources.Writer|6.0.0.0\",\"System.Runtime.CompilerServices.Unsafe|6.0.0.0\",\"System.Runtime.CompilerServices.VisualC|6.0.0.0\",\"System.Runtime.Extensions|6.0.0.0\",\"System.Runtime.Handles|6.0.0.0\",\"System.Runtime.InteropServices.RuntimeInformation|6.0.0.0\",\"System.Runtime.InteropServices|6.0.0.0\",\"System.Runtime.Intrinsics|6.0.0.0\",\"System.Runtime.Loader|6.0.0.0\",\"System.Runtime.Numerics|6.0.0.0\",\"System.Runtime.Serialization.Formatters|6.0.0.0\",\"System.Runtime.Serialization.Json|6.0.0.0\",\"System.Runtime.Serialization.Primitives|6.0.0.0\",\"System.Runtime.Serialization.Xml|6.0.0.0\",\"System.Runtime.Serialization|4.0.0.0\",\"System.Runtime|6.0.0.0\",\"System.Security.AccessControl|6.0.0.0\",\"System.Security.Claims|6.0.0.0\",\"System.Security.Cryptography.Algorithms|6.0.0.0\",\"System.Security.Cryptography.Cng|6.0.0.0\",\"System.Security.Cryptography.Csp|6.0.0.0\",\"System.Security.Cryptography.Encoding|6.0.0.0\",\"System.Security.Cryptography.OpenSsl|6.0.0.0\",\"System.Security.Cryptography.Primitives|6.0.0.0\",\"System.Security.Cryptography.X509Certificates|6.0.0.0\",\"System.Security.Principal.Windows|6.0.0.0\",\"System.Security.Principal|6.0.0.0\",\"System.Security.SecureString|6.0.0.0\",\"System.Security|4.0.0.0\",\"System.ServiceModel.Web|4.0.0.0\",\"System.ServiceProcess|4.0.0.0\",\"System.Text.Encoding.CodePages|6.0.0.0\",\"System.Text.Encoding.Extensions|6.0.0.0\",\"System.Text.Encoding|6.0.0.0\",\"System.Text.Encodings.Web|6.0.0.0\",\"System.Text.Json|6.0.0.0\",\"System.Text.RegularExpressions|6.0.0.0\",\"System.Threading.Channels|6.0.0.0\",\"System.Threading.Overlapped|6.0.0.0\",\"System.Threading.Tasks.Dataflow|6.0.0.0\",\"System.Threading.Tasks.Extensions|6.0.0.0\",\"System.Threading.Tasks.Parallel|6.0.0.0\",\"System.Threading.Tasks|6.0.0.0\",\"System.Threading.Thread|6.0.0.0\",\"System.Threading.ThreadPool|6.0.0.0\",\"System.Threading.Timer|6.0.0.0\",\"System.Threading|6.0.0.0\",\"System.Transactions.Local|6.0.0.0\",\"System.Transactions|4.0.0.0\",\"System.ValueTuple|4.0.3.0\",\"System.Web.HttpUtility|6.0.0.0\",\"System.Web|4.0.0.0\",\"System.Windows|4.0.0.0\",\"System.Xml.Linq|4.0.0.0\",\"System.Xml.ReaderWriter|6.0.0.0\",\"System.Xml.Serialization|4.0.0.0\",\"System.Xml.XDocument|6.0.0.0\",\"System.Xml.XPath.XDocument|6.0.0.0\",\"System.Xml.XPath|6.0.0.0\",\"System.Xml.XmlDocument|6.0.0.0\",\"System.Xml.XmlSerializer|6.0.0.0\",\"System.Xml|4.0.0.0\",\"System|4.0.0.0\",\"WindowsBase|4.0.0.0\",\"mscorlib|4.0.0.0\",\"netstandard|2.1.0.0\"],\"id\":\"Microsoft.NETCore.App.Ref\",\"sha512\":\"sha512-quj/gyLoZLypJO7PwsZ8ib6ZSgFv1C9s5SJgwzl/gztynTJ/3oO/stA2gNMf0C33vTJ0J3SSF/kRPQ/ifY5xZg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[\"Microsoft.CSharp|4.4.0\",\"Microsoft.Win32.Primitives|4.3.0\",\"Microsoft.Win32.Registry|4.4.0\",\"runtime.debian.8-x64.runtime.native.System|4.3.0\",\"runtime.debian.8-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.debian.8-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.debian.8-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"runtime.fedora.23-x64.runtime.native.System|4.3.0\",\"runtime.fedora.23-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.fedora.23-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.fedora.23-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"runtime.fedora.24-x64.runtime.native.System|4.3.0\",\"runtime.fedora.24-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.fedora.24-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.fedora.24-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"runtime.opensuse.13.2-x64.runtime.native.System|4.3.0\",\"runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.opensuse.13.2-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.opensuse.13.2-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"runtime.opensuse.42.1-x64.runtime.native.System|4.3.0\",\"runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.opensuse.42.1-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.opensuse.42.1-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"runtime.osx.10.10-x64.runtime.native.System|4.3.0\",\"runtime.osx.10.10-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.osx.10.10-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.osx.10.10-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple|4.3.0\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"runtime.rhel.7-x64.runtime.native.System|4.3.0\",\"runtime.rhel.7-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.rhel.7-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.rhel.7-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"runtime.ubuntu.14.04-x64.runtime.native.System|4.3.0\",\"runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"runtime.ubuntu.16.04-x64.runtime.native.System|4.3.0\",\"runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"runtime.ubuntu.16.10-x64.runtime.native.System|4.3.0\",\"runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"System.AppContext|4.3.0\",\"System.Buffers|4.4.0\",\"System.Collections|4.3.0\",\"System.Collections.Concurrent|4.3.0\",\"System.Collections.Immutable|1.4.0\",\"System.Collections.NonGeneric|4.3.0\",\"System.Collections.Specialized|4.3.0\",\"System.ComponentModel|4.3.0\",\"System.ComponentModel.EventBasedAsync|4.3.0\",\"System.ComponentModel.Primitives|4.3.0\",\"System.ComponentModel.TypeConverter|4.3.0\",\"System.Console|4.3.0\",\"System.Data.Common|4.3.0\",\"System.Diagnostics.Contracts|4.3.0\",\"System.Diagnostics.Debug|4.3.0\",\"System.Diagnostics.DiagnosticSource|4.4.0\",\"System.Diagnostics.FileVersionInfo|4.3.0\",\"System.Diagnostics.Process|4.3.0\",\"System.Diagnostics.StackTrace|4.3.0\",\"System.Diagnostics.TextWriterTraceListener|4.3.0\",\"System.Diagnostics.Tools|4.3.0\",\"System.Diagnostics.TraceSource|4.3.0\",\"System.Diagnostics.Tracing|4.3.0\",\"System.Dynamic.Runtime|4.3.0\",\"System.Globalization|4.3.0\",\"System.Globalization.Calendars|4.3.0\",\"System.Globalization.Extensions|4.3.0\",\"System.IO|4.3.0\",\"System.IO.Compression|4.3.0\",\"System.IO.Compression.ZipFile|4.3.0\",\"System.IO.FileSystem|4.3.0\",\"System.IO.FileSystem.AccessControl|4.4.0\",\"System.IO.FileSystem.DriveInfo|4.3.0\",\"System.IO.FileSystem.Primitives|4.3.0\",\"System.IO.FileSystem.Watcher|4.3.0\",\"System.IO.IsolatedStorage|4.3.0\",\"System.IO.MemoryMappedFiles|4.3.0\",\"System.IO.Pipes|4.3.0\",\"System.IO.UnmanagedMemoryStream|4.3.0\",\"System.Linq|4.3.0\",\"System.Linq.Expressions|4.3.0\",\"System.Linq.Queryable|4.3.0\",\"System.Net.Http|4.3.0\",\"System.Net.NameResolution|4.3.0\",\"System.Net.Primitives|4.3.0\",\"System.Net.Requests|4.3.0\",\"System.Net.Security|4.3.0\",\"System.Net.Sockets|4.3.0\",\"System.Net.WebHeaderCollection|4.3.0\",\"System.ObjectModel|4.3.0\",\"System.Private.DataContractSerialization|4.3.0\",\"System.Reflection|4.3.0\",\"System.Reflection.Emit|4.3.0\",\"System.Reflection.Emit.ILGeneration|4.3.0\",\"System.Reflection.Emit.Lightweight|4.3.0\",\"System.Reflection.Extensions|4.3.0\",\"System.Reflection.Metadata|1.5.0\",\"System.Reflection.Primitives|4.3.0\",\"System.Reflection.TypeExtensions|4.3.0\",\"System.Resources.ResourceManager|4.3.0\",\"System.Runtime|4.3.0\",\"System.Runtime.Extensions|4.3.0\",\"System.Runtime.Handles|4.3.0\",\"System.Runtime.InteropServices|4.3.0\",\"System.Runtime.InteropServices.RuntimeInformation|4.3.0\",\"System.Runtime.Loader|4.3.0\",\"System.Runtime.Numerics|4.3.0\",\"System.Runtime.Serialization.Formatters|4.3.0\",\"System.Runtime.Serialization.Json|4.3.0\",\"System.Runtime.Serialization.Primitives|4.3.0\",\"System.Security.AccessControl|4.4.0\",\"System.Security.Claims|4.3.0\",\"System.Security.Cryptography.Algorithms|4.3.0\",\"System.Security.Cryptography.Cng|4.4.0\",\"System.Security.Cryptography.Csp|4.3.0\",\"System.Security.Cryptography.Encoding|4.3.0\",\"System.Security.Cryptography.OpenSsl|4.4.0\",\"System.Security.Cryptography.Primitives|4.3.0\",\"System.Security.Cryptography.X509Certificates|4.3.0\",\"System.Security.Cryptography.Xml|4.4.0\",\"System.Security.Principal|4.3.0\",\"System.Security.Principal.Windows|4.4.0\",\"System.Text.Encoding|4.3.0\",\"System.Text.Encoding.Extensions|4.3.0\",\"System.Text.RegularExpressions|4.3.0\",\"System.Threading|4.3.0\",\"System.Threading.Overlapped|4.3.0\",\"System.Threading.Tasks|4.3.0\",\"System.Threading.Tasks.Extensions|4.3.0\",\"System.Threading.Tasks.Parallel|4.3.0\",\"System.Threading.Thread|4.3.0\",\"System.Threading.ThreadPool|4.3.0\",\"System.Threading.Timer|4.3.0\",\"System.ValueTuple|4.3.0\",\"System.Xml.ReaderWriter|4.3.0\",\"System.Xml.XDocument|4.3.0\",\"System.Xml.XmlDocument|4.3.0\",\"System.Xml.XmlSerializer|4.3.0\",\"System.Xml.XPath|4.3.0\",\"System.Xml.XPath.XDocument|4.3.0\"],\"version\":\"6.0.5\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Microsoft.NETCore.Platforms\",\"sha512\":\"sha512-GTMT/dgCRBCRUj11ssZ8K1FJm6Md+C/tSJl8I7YjxOFwSvopaIneV32y1VlnBTI4wy1SwueI7ou2sVfHkWENrA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.5\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Microsoft.NETCore.Targets\",\"sha512\":\"sha512-hYHm3JAjQO/nySxcl1EpZhYEW+2P3H1eLZNr+QxgO5TnLS6hqtfi5WchjQzjid45MYmhy2X7IOmcWtDP4fpMGw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Microsoft.Web.Xdt\",\"sha512\":\"sha512-3VApgkdgOglJWtrXSgYzz6o8Cp6IpvmFQMeICyQvvbKoy+OjNwco5ovzBBL1HHj7kEgLfe2ruXW/ZQ1k+2YxYw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"3.1.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Microsoft.Win32.SystemEvents\",\"sha512\":\"sha512-tCbvWn9ymrxUuAlYZCQ7eDwVSn7571UIeMYWizWCXPjQlESdfIGr1W6EXhrFm8BgPt2e9G5bJfxVrzx2knWR6A==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Mono.Cecil\",\"sha512\":\"sha512-CnjwUMmFHnScNG8e/4DRZQQX67H5ajekRDudmZ6Fy1jCLhyH1jjzbQCOEFhBLa2NjPWQpMF+RHdBJY8a7GgmlA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"0.11.4\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[\"Microsoft.NETCore.Platforms\"],\"net451\":[\"Microsoft.NETCore.Platforms\"],\"net452\":[\"Microsoft.NETCore.Platforms\"],\"net46\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization.Calendars\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Net.Http\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\"],\"net461\":[\"Microsoft.NETCore.Platforms\"],\"net462\":[\"Microsoft.NETCore.Platforms\"],\"net47\":[\"Microsoft.NETCore.Platforms\"],\"net471\":[\"Microsoft.NETCore.Platforms\"],\"net472\":[\"Microsoft.NETCore.Platforms\"],\"net48\":[\"Microsoft.NETCore.Platforms\"],\"net5.0\":[\"Microsoft.NETCore.Platforms\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Linq\",\"System.Net.Http\",\"System.Net.Primitives\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Linq\",\"System.Net.Http\",\"System.Net.Primitives\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Linq\",\"System.Net.Primitives\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.IO\",\"System.Linq\",\"System.Net.Http\",\"System.Net.Primitives\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.IO\",\"System.Linq\",\"System.Net.Http\",\"System.Net.Primitives\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Linq\",\"System.Net.Http\",\"System.Net.Primitives\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Linq\",\"System.Net.Http\",\"System.Net.Primitives\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Linq\",\"System.Net.Http\",\"System.Net.Primitives\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Linq\",\"System.Net.Http\",\"System.Net.Primitives\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\"]},\"framework_list\":[],\"id\":\"NETStandard.Library\",\"sha512\":\"sha512-548M6mnBSJWxsIlkQHfbzoYxpiYFXZZSL00p4GHYv8PkiqFBnnT68mW5mGEsA/ch9fDO9GkPgkFQpWiXZN7mAQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"2.0.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[\"Microsoft.CSharp\",\"NETStandard.Library\"],\"netcoreapp1.1\":[\"Microsoft.CSharp\",\"NETStandard.Library\"],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.CSharp\",\"NETStandard.Library\"],\"netstandard1.1\":[\"Microsoft.CSharp\",\"NETStandard.Library\"],\"netstandard1.2\":[\"Microsoft.CSharp\",\"NETStandard.Library\"],\"netstandard1.3\":[\"Microsoft.CSharp\",\"NETStandard.Library\"],\"netstandard1.4\":[\"Microsoft.CSharp\",\"NETStandard.Library\"],\"netstandard1.5\":[\"Microsoft.CSharp\",\"NETStandard.Library\"],\"netstandard1.6\":[\"Microsoft.CSharp\",\"NETStandard.Library\"],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Newtonsoft.Json\",\"sha512\":\"sha512-g3MbZi6vBTeaI/hEbvR7vBETSd1DWLe9i1E4P+nPY34v5i94zqUqDXvdWC3G+7tYN9SnsdU9zzegrnRz4h7nsQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"13.0.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"net462\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"net47\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"net471\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"net472\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"net48\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"net5.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"net6.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"net7.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"net8.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"netcoreapp2.1\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"netcoreapp2.2\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"netcoreapp3.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"netcoreapp3.1\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"],\"netstandard2.1\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\",\"Microsoft.Extensions.FileProviders.Abstractions\",\"Microsoft.Extensions.FileSystemGlobbing\"]},\"framework_list\":[],\"id\":\"NuGet.Commands\",\"sha512\":\"sha512-+fjzHcRYfT61xykFQfdAtRW5OMrqKRm2jwCPmGLWQn/uSGE9zEdKJD+HByWjV1EzJ/01FIYrKB94zg0ShDKjJQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.7.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Frameworks\"],\"net462\":[\"NuGet.Frameworks\"],\"net47\":[\"NuGet.Frameworks\"],\"net471\":[\"NuGet.Frameworks\"],\"net472\":[\"NuGet.Frameworks\"],\"net48\":[\"NuGet.Frameworks\"],\"net5.0\":[\"NuGet.Frameworks\"],\"net6.0\":[\"NuGet.Frameworks\"],\"net7.0\":[\"NuGet.Frameworks\"],\"net8.0\":[\"NuGet.Frameworks\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Frameworks\"],\"netcoreapp2.1\":[\"NuGet.Frameworks\"],\"netcoreapp2.2\":[\"NuGet.Frameworks\"],\"netcoreapp3.0\":[\"NuGet.Frameworks\"],\"netcoreapp3.1\":[\"NuGet.Frameworks\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Frameworks\"],\"netstandard2.1\":[\"NuGet.Frameworks\"]},\"framework_list\":[],\"id\":\"NuGet.Common\",\"sha512\":\"sha512-xxmTBZqBfMCaou4rJFKReYbTrfQXb4OfcT9QyVLN1nEe36KditRl0Uki0R03RVimNKeTzKjBUF6I4CZTAeu2YQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.7.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"net462\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"net47\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"net471\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"net472\":[\"NuGet.Common\"],\"net48\":[\"NuGet.Common\"],\"net5.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"net6.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"net7.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"net8.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp2.1\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp2.2\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp3.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp3.1\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netstandard2.1\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"]},\"framework_list\":[],\"id\":\"NuGet.Configuration\",\"sha512\":\"sha512-MqkkKtRGH3Z73v1WylGpDMoUrVlNqoEFcaWE1Apudb6AWJYqGh4vyZUMdXsitoVpiakP3iiAMtprh4Gfa/Cv6Q==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.7.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Protocol\"],\"net462\":[\"NuGet.Protocol\"],\"net47\":[\"NuGet.Protocol\"],\"net471\":[\"NuGet.Protocol\"],\"net472\":[\"NuGet.Protocol\"],\"net48\":[\"NuGet.Protocol\"],\"net5.0\":[\"NuGet.Protocol\"],\"net6.0\":[\"NuGet.Protocol\"],\"net7.0\":[\"NuGet.Protocol\"],\"net8.0\":[\"NuGet.Protocol\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Protocol\"],\"netcoreapp2.1\":[\"NuGet.Protocol\"],\"netcoreapp2.2\":[\"NuGet.Protocol\"],\"netcoreapp3.0\":[\"NuGet.Protocol\"],\"netcoreapp3.1\":[\"NuGet.Protocol\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Protocol\"],\"netstandard2.1\":[\"NuGet.Protocol\"]},\"framework_list\":[],\"id\":\"NuGet.Credentials\",\"sha512\":\"sha512-G5JCMbC24Cd0wFz7fZCXRKF5ZqWcm6UGwA3Y+nC9/pbV9sIkPKEsDYk6/QUBLIVnXbB3J1o5zgULa95QJ99bAg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.7.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net462\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net47\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net471\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net472\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net48\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net5.0\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net6.0\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net7.0\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net8.0\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netcoreapp2.1\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netcoreapp2.2\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netcoreapp3.0\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netcoreapp3.1\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netstandard2.1\":[\"NuGet.Configuration\",\"NuGet.LibraryModel\",\"NuGet.Protocol\"]},\"framework_list\":[],\"id\":\"NuGet.DependencyResolver.Core\",\"sha512\":\"sha512-8SGR7UF/A+tAgdTRIsh3v8qg47w9farAAXvHlbYylL+sFRIp36yGF0C1sXMuD/DEIl6GLc2M/UdawB+FpHg/tw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.7.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"NuGet.Frameworks\",\"sha512\":\"sha512-weGyDjVXp4LUKR9ZjMrtd38J6MkUC5xPU9hcGdksZBB0r+bJmKoZ5NJQAXLFbP3m5BhPLYIl3/aEmPlkCV25Og==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.7.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net462\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net47\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net471\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net472\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net48\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net5.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net6.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net7.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net8.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netcoreapp2.1\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netcoreapp2.2\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netcoreapp3.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netcoreapp3.1\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netstandard2.1\":[\"NuGet.Common\",\"NuGet.Versioning\"]},\"framework_list\":[],\"id\":\"NuGet.LibraryModel\",\"sha512\":\"sha512-YPHMmVII4QqjShzNUX61qg4u/j9mFhBD5iLDCnk8UgEmiWzQRLDFCvXCmbRoYznLJz2995sD7idtqWsvOh4YnA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.7.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net462\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net47\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net471\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net472\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\"],\"net48\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\"],\"net5.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net6.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net7.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net8.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netcoreapp2.1\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netcoreapp2.2\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netcoreapp3.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netcoreapp3.1\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netstandard2.1\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.CSharp\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"]},\"framework_list\":[],\"id\":\"NuGet.PackageManagement\",\"sha512\":\"sha512-QMP/PiheJgBQsP66XNmhdBqnpeyRmqfZjhsfAhjMgm8gfd2k6OGXb2LOV7hN6xbfbj9KrtMiwfzOvuZA6q27KQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.7.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"net462\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"net47\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"net471\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"net472\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\"],\"net48\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\"],\"net5.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"net6.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"net7.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"net8.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"netcoreapp2.1\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"netcoreapp2.2\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"netcoreapp3.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"netcoreapp3.1\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"],\"netstandard2.1\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Pkcs\"]},\"framework_list\":[],\"id\":\"Nuget.Packaging\",\"sha512\":\"sha512-jEfG/a8hNhTDSWOadBi0nZRdTO+PXR98j4u6RnZ68Nyuw4LHviEXOG1kqZvraU3uYGssAoJatkFDYAM8kEX+WQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.7.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.DependencyResolver.Core\"],\"net462\":[\"NuGet.DependencyResolver.Core\"],\"net47\":[\"NuGet.DependencyResolver.Core\"],\"net471\":[\"NuGet.DependencyResolver.Core\"],\"net472\":[\"NuGet.DependencyResolver.Core\"],\"net48\":[\"NuGet.DependencyResolver.Core\"],\"net5.0\":[\"NuGet.DependencyResolver.Core\"],\"net6.0\":[\"NuGet.DependencyResolver.Core\"],\"net7.0\":[\"NuGet.DependencyResolver.Core\"],\"net8.0\":[\"NuGet.DependencyResolver.Core\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.DependencyResolver.Core\"],\"netcoreapp2.1\":[\"NuGet.DependencyResolver.Core\"],\"netcoreapp2.2\":[\"NuGet.DependencyResolver.Core\"],\"netcoreapp3.0\":[\"NuGet.DependencyResolver.Core\"],\"netcoreapp3.1\":[\"NuGet.DependencyResolver.Core\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.DependencyResolver.Core\"],\"netstandard2.1\":[\"NuGet.DependencyResolver.Core\"]},\"framework_list\":[],\"id\":\"NuGet.ProjectModel\",\"sha512\":\"sha512-BnheauzOjo1U/hCg0jyhflaNbffCbfZnquHc18+VneSANMB54Mg/xjHPLibx3R5zneQ6E3n0K50wtfRntrkH8g==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.7.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"NuGet.Protocol\",\"sha512\":\"sha512-/r+i3gmVYWa8KMETanGyaCqMPVLTwe8Gqza5khiDiETATeGEd+y7erJsy/pLwBpnl0/jSYpf+kxPq16xoiej6A==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.7.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Protocol\"],\"net462\":[\"NuGet.Protocol\"],\"net47\":[\"NuGet.Protocol\"],\"net471\":[\"NuGet.Protocol\"],\"net472\":[\"NuGet.Protocol\"],\"net48\":[\"NuGet.Protocol\"],\"net5.0\":[\"NuGet.Protocol\"],\"net6.0\":[\"NuGet.Protocol\"],\"net7.0\":[\"NuGet.Protocol\"],\"net8.0\":[\"NuGet.Protocol\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Protocol\"],\"netcoreapp2.1\":[\"NuGet.Protocol\"],\"netcoreapp2.2\":[\"NuGet.Protocol\"],\"netcoreapp3.0\":[\"NuGet.Protocol\"],\"netcoreapp3.1\":[\"NuGet.Protocol\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Protocol\"],\"netstandard2.1\":[\"NuGet.Protocol\"]},\"framework_list\":[],\"id\":\"NuGet.Resolver\",\"sha512\":\"sha512-kLoXgmxb0dpzK5Dx1SiaTj2l0EXtU42HSMD9bQgjoc3BWi/5Fn6VvGe8Pd7U4firGmvxgkmmO0lJx6iF0dLLxQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.7.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"NuGet.Versioning\",\"sha512\":\"sha512-aZ0/Fd85juLKrg0rZw4rWJAFDuv0aW3SJj3fqwp5etkRZOwHO/11vmGh0eeMZ7gMAvnktvxax7h5Vaxkllv2ZA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.7.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"net462\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"net47\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"net471\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"net472\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"net48\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"net5.0\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"net6.0\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"net7.0\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"net8.0\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp2.1\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp2.2\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp3.0\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp3.1\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"],\"netstandard2.1\":[\"Chessie\",\"FSharp.Core\",\"Mono.Cecil\",\"Newtonsoft.Json\",\"Nuget.Packaging\",\"System.Net.Http\",\"System.Net.Http.WinHttpHandler\",\"System.Security.Cryptography.ProtectedData\"]},\"framework_list\":[],\"id\":\"Paket.Core\",\"sha512\":\"sha512-Wn1E0lIbjitqogRA6sLRJLxKeIjqLLi5oeFClqGCwUBixPIZ58KM75NwtDAtbiyTqo7KdNBSoAuBI7z4P8lL5w==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"8.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-s9AMelYhmifrJqGjkRkqyoP7NMudky0vJPdYzjGKryWYhofREwzC4EesqYm+dooMQB++vbgvGrtrcZpU36Q+sA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-1kcSfJKTg00KxR43jsnYjjYTPoUh+f+OLpL4/yF/bzKikgxV6QPlz74UyrypYprz3NUHHOcsa12E7+Xp4RtTng==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-DPcJlXiNYg8lqqCAFTgaL9Yqs1brKG3H6b1XVimLf9RYxW7zOLujvf3HfTlvrYEWsAulgJ/+7Gh0mCw4FUt+IQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-2p9EjZTy8LkH/wx6OwRuk0ORuVL7PzqJ3cdvL/SY58Ep+XW0AYEBjyy7kloJ/nPZGYVUT+NS8kNwPU5ICV/DwQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-2v5kHzEZgBFCz+5NJgZn3Dmi9gaYY/loR5PJEXvOJ018XIF6BmSGYNyHNXTmdFPq50EjwaGpHj8cQmR3z5oeGA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-qfB0WU/HXLYhTlXpDZi0eY1p1x9jlwxDlVFcWrj9u+2gFEesUKux9IoR9bzQLPPj//B0dSWolKEgW/1X70VWCA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net20\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net30\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net35\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net40\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net403\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net45\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net451\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net452\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net46\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net461\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net462\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net47\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net471\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net472\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net48\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"]},\"framework_list\":[],\"id\":\"runtime.native.System\",\"sha512\":\"sha512-AJsN0GLPijYtmFZdvPYnfTdAMTlvMttusjye6ZC1Edg5XUneNv1BCHzXfM0SWpqf+Gt/31WthibAPAorcN4F1g==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.1\"}",
+                "{\"dependencies\":{\"net11\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net20\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net30\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net35\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net40\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net403\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net45\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net451\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net452\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net46\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net461\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net462\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net47\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net471\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net472\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net48\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"]},\"framework_list\":[],\"id\":\"runtime.native.System.Net.Http\",\"sha512\":\"sha512-n3clBjCv4nEoDl/hV4/DYwi/yoRrFZk9Tpe0TenLiITLHvtijO+OSYhwV7JmACcsZlLFKMaYW+P5yN3sK/xU0Q==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.1\"}",
+                "{\"dependencies\":{\"net11\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net20\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net30\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net35\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net40\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net403\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net45\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net451\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net452\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net46\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net461\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net462\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net47\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net471\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net472\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net48\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net5.0\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net6.0\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net7.0\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"net8.0\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netcoreapp1.0\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netcoreapp1.1\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netcoreapp2.0\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netcoreapp2.1\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netcoreapp2.2\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netcoreapp3.0\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netcoreapp3.1\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netstandard\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netstandard1.0\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netstandard1.1\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netstandard1.2\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netstandard1.3\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netstandard1.4\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netstandard1.5\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netstandard1.6\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netstandard2.0\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"],\"netstandard2.1\":[\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\"]},\"framework_list\":[],\"id\":\"runtime.native.System.Security.Cryptography.Apple\",\"sha512\":\"sha512-C+AZUmQBFgXR/NxF80q0Sy7SgYiW+C3CcIuA7yd0f1FXWN16xhIRSmXN92IUSGx/ebGN3XmaeuVUZpd+NuY/jQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.1\"}",
+                "{\"dependencies\":{\"net11\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net20\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net30\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net35\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net40\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net403\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net45\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net451\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net452\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net46\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net461\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net462\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net47\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net471\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net472\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net48\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net5.0\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net6.0\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net7.0\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"net8.0\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netcoreapp1.0\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netcoreapp1.1\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netcoreapp2.0\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netcoreapp2.1\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netcoreapp2.2\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netcoreapp3.0\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netcoreapp3.1\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netstandard\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netstandard1.0\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netstandard1.1\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netstandard1.2\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netstandard1.3\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netstandard1.4\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netstandard1.5\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netstandard1.6\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netstandard2.0\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"],\"netstandard2.1\":[\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.debian.9-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.27-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.fedora.28-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\"]},\"framework_list\":[],\"id\":\"runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-CiS94rEK+DWQJJbFqOc+SboSZQeswgRiao5QMZjHjhhRPi2NkawZZ0l99i8+eGNTVo6f4cYTOXVmNr0BeJTiYQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-kbvMwf5iS0oM7qiHPy3sHADQa2ncqFXVz7bQKCiPKcnNu5NTDz4cO/Nk4gy54iYjU0SSma/z2IfYIpPGVsdiZA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-anMSS/nfTUvTuvUE3jg+sSEx7JUgLkeYS7T9dbb8ZE42XYWdaLJjRlp3qA/yYyoewJuVJ6ZPeI8w9QrlKgVSow==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.opensuse.42.3-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-KHQzsD6iTnD3Rpr+Odhe0II9LMwTJkIOMKekGzBz5TQlNbEpuc0LwQxMuCE4FZnzcefRYw3kDd5Xyu+AFND8FQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple\",\"sha512\":\"sha512-YVeP6XccbJen1k3sjfntjqWS+vAcVt37VW3eBuZvjH7ZlTmQz3t6n8gLNh342IeDSBM+06SPYtBqP1roAlIpDA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-KBHT4RWCC3klyYzHWLweXSAPRzPLuzFdfixnzojA+tNUE6kHpyABhtbgTiwhGHyA3+TlyLOn1viw1NBoG7ZOxQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-Lmw34chaD1jDOrmiEl2jIXVoCfYhTFMWQWtC47RDRLKYpwLOjOkSa6E2LM5K28UNpkSOZu579Os/t+eZ+wAhOw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-K6KLKN1ICpOqvVG2Dub+uX3gb/MqqiS1deVZpuj46M7ya9ranrGzFYVIMsQFI8f7vhc+sf0gyTtN0es9tN4jmw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-IXiZH+OL4lP8dRKieebADFgWPgyq/vbMbYqXCz9EhfaU4CcRl1ygb3pmpNWhVJsVEV3fRb3tEaEFowmkb56WCQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-uOpq6ML3XC+QioF01mDpg6zuJEZs23+vjpbnOKQkZxyMSOGNanyleAjNgXLZyUo0NPa5c8QIMB878SvxLSxjhA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"runtime.ubuntu.18.04-x64.runtime.native.System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-fefg8Dxuv7BKypFbd1HKIdO/x51l+NN4WP5GIqe+Gx6El1Aut7zZA5a9B8WPowDiGCwPIqEJaIhdwCjmbHqscQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.Collections\",\"sha512\":\"sha512-ynuVLTDaFIfKTkOqUigXte4m5+EFNwYoEBEvxnp1EnZsOdQC85S7BCbREIu8+bu2Tpzh9a9zbvIVpRo15V8FGw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"net6.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"net7.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"net8.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp1.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp1.1\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp2.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp2.1\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp2.2\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp3.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp3.1\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netstandard1.2\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netstandard1.3\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.4\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.5\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.6\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard2.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard2.1\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Threading\",\"System.Threading.Tasks\"]},\"framework_list\":[],\"id\":\"System.Collections.Concurrent\",\"sha512\":\"sha512-NcGqPmNiFv5dwuvrUEKT5prWNV0m4iRTrwYK+U2CefqpO9z+EnrssLMWx+fZGFvKxy6ZSYTv238thRXx9Vz2gg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.ComponentModel.Composition\",\"sha512\":\"sha512-YWQ3ENu0D2st9ZV+Yj4u3IFcas0Pw7S4c7ymDUooPLb1psNJ53YniX2orSiY2OlRWnssaUsTytnVJa/KfCn5aA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"System.Security.Permissions\"],\"net462\":[\"System.Security.Permissions\"],\"net47\":[\"System.Security.Permissions\"],\"net471\":[\"System.Security.Permissions\"],\"net472\":[\"System.Security.Permissions\"],\"net48\":[\"System.Security.Permissions\"],\"net5.0\":[\"System.Security.Cryptography.ProtectedData\",\"System.Security.Permissions\"],\"net6.0\":[\"System.Security.Cryptography.ProtectedData\",\"System.Security.Permissions\"],\"net7.0\":[\"System.Security.Cryptography.ProtectedData\",\"System.Security.Permissions\"],\"net8.0\":[\"System.Security.Cryptography.ProtectedData\",\"System.Security.Permissions\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"System.Security.Cryptography.ProtectedData\",\"System.Security.Permissions\"],\"netcoreapp2.1\":[\"System.Security.Cryptography.ProtectedData\",\"System.Security.Permissions\"],\"netcoreapp2.2\":[\"System.Security.Cryptography.ProtectedData\",\"System.Security.Permissions\"],\"netcoreapp3.0\":[\"System.Security.Cryptography.ProtectedData\",\"System.Security.Permissions\"],\"netcoreapp3.1\":[\"System.Security.Cryptography.ProtectedData\",\"System.Security.Permissions\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"System.Security.Cryptography.ProtectedData\",\"System.Security.Permissions\"],\"netstandard2.1\":[\"System.Security.Cryptography.ProtectedData\",\"System.Security.Permissions\"]},\"framework_list\":[],\"id\":\"System.Configuration.ConfigurationManager\",\"sha512\":\"sha512-3ljLko1jA6FjAf16qO2sN53+bEfm2AshZl+SurndX/UrPiRM9t8PlF8ccucckjN1YdvydS/DMkF0qMnsxwwyRw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.Diagnostics.Debug\",\"sha512\":\"sha512-bFj+HjYY5/h2hMHOp+/H07Gb19+NJTX54ntixS9EHxG2eyEiXWvNYvQJ4CwqFiMcTbGb4zuPq1ubClyGYN2rJA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net462\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net47\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net471\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net472\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net48\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net5.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net6.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net7.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"net8.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp2.1\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp2.2\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp3.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp3.1\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netstandard2.1\":[\"System.Runtime.CompilerServices.Unsafe\"]},\"framework_list\":[],\"id\":\"System.Diagnostics.DiagnosticSource\",\"sha512\":\"sha512-dYnmo66bitfHxLjNBU2LPp6Dn98n7hRyk7ZKGVzaAPw2MHy+40dLxfw7susxMkWfL3C//aJF+/UDAPgH2YhUZg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.Diagnostics.Tracing\",\"sha512\":\"sha512-0KXTDiYc1Ft9+rArf/vXa2TgybiS7YJuphSByYPAIIsFtpmBzXnpHNTlgR4c1MPOoGoa/OBYEezli+XkwgFp6g==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.Win32.SystemEvents\"],\"net6.0\":[\"Microsoft.Win32.SystemEvents\"],\"net7.0\":[\"Microsoft.Win32.SystemEvents\"],\"net8.0\":[\"Microsoft.Win32.SystemEvents\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[\"Microsoft.Win32.SystemEvents\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Drawing.Common\",\"sha512\":\"sha512-1h8KPgHD6sFfE/wboEosfOTqyVZACy+qNh/sq9ODbUnVvTRPOYXuPZTNw/anK44H5CPNspZbT1yiIitd4ymI5A==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Formats.Asn1\",\"sha512\":\"sha512-KAcODhtEEDJs6494uw0/s/BxymRWD1yV4JHd0QOx8IV4B8JocCvk2mfOmmwVptBxydT25WJvOnzmh2vjoqbbwg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"8.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.Globalization\",\"sha512\":\"sha512-gj0rowjLBztAoxRuzM0Nn9exYVrD+++xb3PYc+QR/YHDvch98gbT3H4vFMnNU6r8poSjVwwlRxKAqtqN6AXs4g==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.Globalization.Calendars\",\"sha512\":\"sha512-6XGQIxQCs5N3S5Je/AKiv6QdHRF6F/uH2m45n1I0VGlidn6c2POZcO+kCOT0U80eZ1Giph42a8l0BuGwuKS+hg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.InteropServices\"]},\"framework_list\":[],\"id\":\"System.Globalization.Extensions\",\"sha512\":\"sha512-pNNgAD+V4MMe3znAuR4cc4UKYKxdADKxfbiIo8fXE0zvms2XIZ0UF0rSE7fARPSbNkzFcgBz6/y24b9uTsJM5Q==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"]},\"framework_list\":[],\"id\":\"System.IO\",\"sha512\":\"sha512-v8paIePhmGuXZbE9xvvNb4uJ5ME4OFXR1+8la/G/L1GIl2nbU2WFnddgb79kVK3U2us7q1aZT/uY/R0D/ovB5g==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[\"System.IO.FileSystem.Primitives\"],\"net461\":[\"System.IO.FileSystem.Primitives\"],\"net462\":[\"System.IO.FileSystem.Primitives\"],\"net47\":[\"System.IO.FileSystem.Primitives\"],\"net471\":[\"System.IO.FileSystem.Primitives\"],\"net472\":[\"System.IO.FileSystem.Primitives\"],\"net48\":[\"System.IO.FileSystem.Primitives\"],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.IO.FileSystem.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Text.Encoding\",\"System.Threading.Tasks\"]},\"framework_list\":[],\"id\":\"System.IO.FileSystem\",\"sha512\":\"sha512-T7WB1vhblSmgkaDpdGM3Uqo55Qsr5sip5eyowrwiXOoHBkzOx3ePd9+Zh97r9NzOwFCxqX7awO6RBxQuao7n7g==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"System.Runtime\"],\"net6.0\":[\"System.Runtime\"],\"net7.0\":[\"System.Runtime\"],\"net8.0\":[\"System.Runtime\"],\"netcoreapp1.0\":[\"System.Runtime\"],\"netcoreapp1.1\":[\"System.Runtime\"],\"netcoreapp2.0\":[\"System.Runtime\"],\"netcoreapp2.1\":[\"System.Runtime\"],\"netcoreapp2.2\":[\"System.Runtime\"],\"netcoreapp3.0\":[\"System.Runtime\"],\"netcoreapp3.1\":[\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[\"System.Runtime\"],\"netstandard1.4\":[\"System.Runtime\"],\"netstandard1.5\":[\"System.Runtime\"],\"netstandard1.6\":[\"System.Runtime\"],\"netstandard2.0\":[\"System.Runtime\"],\"netstandard2.1\":[\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.IO.FileSystem.Primitives\",\"sha512\":\"sha512-WIWVPQlYLP/Zc9I6IakpBk1y8ryVGK83MtZx//zGKKi2hvHQWKAB7moRQCOz5Is/wNDksiYpocf3FeA3le6e5Q==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"net6.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"net7.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"net8.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp1.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp1.1\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp2.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp2.1\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp2.2\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp3.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp3.1\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netstandard\":[],\"netstandard1.0\":[\"System.Collections\",\"System.Runtime\"],\"netstandard1.1\":[\"System.Collections\",\"System.Runtime\"],\"netstandard1.2\":[\"System.Collections\",\"System.Runtime\"],\"netstandard1.3\":[\"System.Collections\",\"System.Runtime\"],\"netstandard1.4\":[\"System.Collections\",\"System.Runtime\"],\"netstandard1.5\":[\"System.Collections\",\"System.Runtime\"],\"netstandard1.6\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netstandard2.0\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netstandard2.1\":[\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"]},\"framework_list\":[],\"id\":\"System.Linq\",\"sha512\":\"sha512-6sx/4exSb0BfW6DmcfYW0OW+nBgo1UOp4vjGXfQJnWsupKn6LNrk80sXDcNxQvYOJn4TfKOfNQKB7XDS3GIEWA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[\"System.Security.Cryptography.X509Certificates\"],\"net461\":[\"System.Security.Cryptography.X509Certificates\"],\"net462\":[\"System.Security.Cryptography.X509Certificates\"],\"net47\":[\"System.Security.Cryptography.X509Certificates\"],\"net471\":[\"System.Security.Cryptography.X509Certificates\"],\"net472\":[\"System.Security.Cryptography.X509Certificates\"],\"net48\":[\"System.Security.Cryptography.X509Certificates\"],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[\"System.IO\",\"System.Net.Primitives\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard1.2\":[\"System.IO\",\"System.Net.Primitives\",\"System.Runtime\",\"System.Text.Encoding\",\"System.Threading.Tasks\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.IO\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.IO\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.IO\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Diagnostics.DiagnosticSource\",\"System.Diagnostics.Tracing\",\"System.Globalization\",\"System.Globalization.Extensions\",\"System.IO\",\"System.IO.FileSystem\",\"System.Net.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Security.Cryptography.X509Certificates\",\"System.Text.Encoding\",\"System.Threading\",\"System.Threading.Tasks\"]},\"framework_list\":[],\"id\":\"System.Net.Http\",\"sha512\":\"sha512-Fj7e73NNHwof97gFPTJuq8gv6G895yxkZt14DVnZdEh4gvKl8WrksCwNjIp/JeYX/yu/qxM/iOv9ai+ZY3Fp7Q==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.4\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Net.Http.WinHttpHandler\",\"sha512\":\"sha512-uLH7CWm9PZaO0SNhnEL8wvLCwcLCjC9M/jWgl7kTwp5PuFCfeCn7hrq6c0Bpfq2s1SCkx9lNUoRWnM76wMpnxQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\",\"System.Runtime.Handles\"]},\"framework_list\":[],\"id\":\"System.Net.Primitives\",\"sha512\":\"sha512-BgdlyYCI7rrdh36p3lMTqbkvaafPETpB1bk9iQlFdQxYE692kiXvmseXs8ghL+gEgQF2xgDc8GH4QLkSgUUs+Q==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.IO\",\"System.Reflection.Primitives\",\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.Reflection\",\"sha512\":\"sha512-IyW2ftYNzgMCgHBk8lQiy+G3+ydbU5tE+6PEqM5JJvIdeFKaXDSzHAPYDREPe6zpr5WJ1Fcma+rAFCIAV6+DMw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\"],\"netcoreapp1.1\":[\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\"],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\"],\"netstandard1.1\":[\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\"],\"netstandard1.2\":[\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\"],\"netstandard1.3\":[\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\"],\"netstandard1.4\":[\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\"],\"netstandard1.5\":[\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\"],\"netstandard1.6\":[\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\"],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Reflection.Emit.Lightweight\",\"sha512\":\"sha512-Blr1A9Vqk+ZUknlk6sFrhOcpuqx4bp7kqwZfhwkmmhz+9dgOl8cZ9CnSXbalbL9rfHmi5HDFydxQsfozl2PvjQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.7.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.Reflection.Primitives\",\"sha512\":\"sha512-1LnMkF9aXKuQAgYzjoiQaL9mwY7oY6KdaO/zzeLMynNBEqKoUfLi5TiKIewoAF+hkxfGTZsjkjsF1jRL4uSeqg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Globalization\",\"System.Reflection\",\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.Resources.ResourceManager\",\"sha512\":\"sha512-kGfbKPHEjQj8Uq1Apgj4jBStkRJkZ0Hdr0Jv3+aL7WGrAZVLF5Rh5h0Yc3FgDB5uXDbHiJk/WhBaZPVwKmuB1A==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\"]},\"framework_list\":[],\"id\":\"System.Runtime\",\"sha512\":\"sha512-Al69mPDfzdD+bKGK2HAfB+lNFOHFqnkqzNnUJmmvUe1/qEPK9M7EiTT4zuycKDPy7ev11xz8XVgJWKP0hm7NIA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Runtime.CompilerServices.Unsafe\",\"sha512\":\"sha512-1AVzAb5OxJNvJLnOADtexNmWgattm2XVOT3TjQTN7Dd4SqoSwai1CsN2fth42uQldJSQdz/sAec0+TzxBFgisw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.Runtime.Extensions\",\"sha512\":\"sha512-VSbBNw3UQxuHk4aALPsYo154l+TKUR4Ij+Nj9GPnyJkzAmMewY1AyHXuaE+KCJ6JBj2SoO4uwLqY4ORKW9JRTw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.Runtime.Handles\",\"sha512\":\"sha512-CluvHdVUv54BvLTOCCyybugreDNk/rR8unMPruzXDtxSjvrQOU3M4R831/lQf4YI8VYp668FGQa/01E+Rq8PEQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[\"System.Runtime\"],\"net47\":[\"System.Runtime\"],\"net471\":[\"System.Runtime\"],\"net472\":[\"System.Runtime\"],\"net48\":[\"System.Runtime\"],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Reflection\",\"System.Reflection.Primitives\",\"System.Runtime\",\"System.Runtime.Handles\"]},\"framework_list\":[],\"id\":\"System.Runtime.InteropServices\",\"sha512\":\"sha512-ZQeZw+ZU77ua1nFXycYM5G8oioFZe+N84qC/XUg1BEBl7z9luZcyjLu7+4H0yJuNfn1hOAiAAZ3u5us/lj9w2Q==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"net6.0\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"net7.0\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"net8.0\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp1.0\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp1.1\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp2.0\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp2.1\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp2.2\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp3.0\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netcoreapp3.1\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[\"System.Runtime\"],\"netstandard1.2\":[\"System.Runtime\"],\"netstandard1.3\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netstandard1.4\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netstandard1.5\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netstandard1.6\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netstandard2.0\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"],\"netstandard2.1\":[\"System.Globalization\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\"]},\"framework_list\":[],\"id\":\"System.Runtime.Numerics\",\"sha512\":\"sha512-PjR/qo5+xITUgeU7HCGf4c40augniiFLRQjPDiM8Fie9nGxsfGVOjB9BQycYON3ZWT9joQQ1d62HxA45Kvf9NA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Security.AccessControl\",\"sha512\":\"sha512-ZKNqEDuVSrS36KdsDodleb1ITDCOREwtkV+5oP0FrWNhRQHtI1xUSvybQxy4pM8PBxW47UFOhZWObWhXkWj7RQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[\"System.Security.Cryptography.Primitives\"],\"net461\":[\"System.Security.Cryptography.Primitives\"],\"net462\":[\"System.Security.Cryptography.Primitives\"],\"net47\":[\"System.IO\",\"System.Runtime\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\"],\"net471\":[\"System.IO\",\"System.Runtime\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\"],\"net472\":[\"System.IO\",\"System.Runtime\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\"],\"net48\":[\"System.IO\",\"System.Runtime\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\"],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[\"System.IO\",\"System.Runtime\",\"System.Security.Cryptography.Primitives\"],\"netstandard1.4\":[\"System.IO\",\"System.Runtime\",\"System.Security.Cryptography.Primitives\"],\"netstandard1.5\":[\"System.IO\",\"System.Runtime\",\"System.Security.Cryptography.Primitives\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.Apple\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"]},\"framework_list\":[],\"id\":\"System.Security.Cryptography.Algorithms\",\"sha512\":\"sha512-NLArYLaaVOExC1EVEuMhCkm/sFhMUPgLWcWG1xgK2XPjtUGfelV4ODeIQ5VGDbPg2xPI+yfebRcLjS2rHJCtzw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Primitives\"],\"net461\":[\"System.Security.Cryptography.Algorithms\"],\"net462\":[\"System.Security.Cryptography.Algorithms\"],\"net47\":[\"System.Security.Cryptography.Algorithms\"],\"net471\":[\"System.Security.Cryptography.Algorithms\"],\"net472\":[\"System.Security.Cryptography.Algorithms\"],\"net48\":[\"System.Security.Cryptography.Algorithms\"],\"net5.0\":[\"System.Formats.Asn1\"],\"net6.0\":[\"System.Formats.Asn1\"],\"net7.0\":[\"System.Formats.Asn1\"],\"net8.0\":[\"System.Formats.Asn1\"],\"netcoreapp1.0\":[\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp1.1\":[\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[\"System.Formats.Asn1\"],\"netcoreapp3.1\":[\"System.Formats.Asn1\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Primitives\"],\"netstandard1.4\":[\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard1.5\":[\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard1.6\":[\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Security.Cryptography.Cng\",\"sha512\":\"sha512-trvkAklUhzM+/z9bPnGmDLzmbvD0l1IlC6gpFRpzjGLylTgtTPqm8Uv7tnDBTuBQObjEZBxNS0bChIi6zQCV9w==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Primitives\"],\"net461\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Primitives\"],\"net462\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Primitives\"],\"net47\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Primitives\"],\"net471\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Primitives\"],\"net472\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Primitives\"],\"net48\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Primitives\"],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"System.IO\",\"System.Reflection\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"]},\"framework_list\":[],\"id\":\"System.Security.Cryptography.Csp\",\"sha512\":\"sha512-QzF1kXR6GPUvaDGH4Jrf4OA1c+baxDC/O6E/RAzbHHux+SBTadXzsqDz/flgTVuh5tlKiZol0sUz5FMzhXjzUQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Collections.Concurrent\",\"System.Linq\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"]},\"framework_list\":[],\"id\":\"System.Security.Cryptography.Encoding\",\"sha512\":\"sha512-XCat0j5jVC83UG9fofcuiYDwN0PVKc2OWD0QVLjYpXn7dz+gNaANkHPbhNtr5PR8rDQNHrxtI912Hb29YAB14A==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"System.Security.Cryptography.Algorithms\"],\"net462\":[\"System.Security.Cryptography.Algorithms\"],\"net47\":[\"System.Security.Cryptography.Algorithms\"],\"net471\":[\"System.Security.Cryptography.Algorithms\"],\"net472\":[\"System.Security.Cryptography.Algorithms\"],\"net48\":[\"System.Security.Cryptography.Algorithms\"],\"net5.0\":[\"System.Formats.Asn1\"],\"net6.0\":[\"System.Formats.Asn1\"],\"net7.0\":[\"System.Formats.Asn1\"],\"net8.0\":[\"System.Formats.Asn1\"],\"netcoreapp1.0\":[\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp1.1\":[\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[\"System.Formats.Asn1\"],\"netcoreapp3.1\":[\"System.Formats.Asn1\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[\"System.Collections\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\"],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Security.Cryptography.OpenSsl\",\"sha512\":\"sha512-+8P4Eo9HMcke1V4bPK6JjBaHilI5MAYLcqPKVHcpbJmW3O6qOCxutBmEiuT3e6CZvk8cE4v2wqC5J3woxqEF/Q==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"net6.0\":[\"System.Formats.Asn1\"],\"net7.0\":[\"System.Formats.Asn1\"],\"net8.0\":[\"System.Formats.Asn1\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"netcoreapp2.1\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"netcoreapp2.2\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"netcoreapp3.0\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"netcoreapp3.1\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"netstandard2.1\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"]},\"framework_list\":[],\"id\":\"System.Security.Cryptography.Pkcs\",\"sha512\":\"sha512-zWk9gw+KSXYnBfrm+nUF7u17gexrNmJOwj0WcLw7kxJB9VAabPTsj9PwPod8QIkSp0q4M/4DTHKhMbc7op2GlQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"8.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"net6.0\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"net7.0\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"net8.0\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp1.0\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp1.1\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp2.0\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp2.1\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp2.2\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp3.0\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netcoreapp3.1\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.4\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.5\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard1.6\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard2.0\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"],\"netstandard2.1\":[\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.IO\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Threading\",\"System.Threading.Tasks\"]},\"framework_list\":[],\"id\":\"System.Security.Cryptography.Primitives\",\"sha512\":\"sha512-WtgnP5mOu5zKL3vQMUPT9tV7XVYGV7Jtb0540DgBD7MMN5ojonwIcw8VybZvS6VloGmE7CRt/Hms8adBsN1DRw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Security.Cryptography.ProtectedData\",\"sha512\":\"sha512-SJtdqwq/rfuLwtBDfeg6FEeRgHGUlEDnZttwHIHDUY3mo4o+D2mXBrBtWRq1OTx7wLLqqBwVv/FWM5JI5sNXMA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\"],\"net461\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\"],\"net462\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\"],\"net47\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\"],\"net471\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\"],\"net472\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\"],\"net48\":[\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\"],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[\"System.Runtime\",\"System.Runtime.Handles\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\"],\"netstandard1.4\":[\"System.Runtime\",\"System.Runtime.Handles\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\"],\"netstandard1.5\":[\"System.Runtime\",\"System.Runtime.Handles\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Encoding\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"runtime.native.System\",\"runtime.native.System.Net.Http\",\"runtime.native.System.Security.Cryptography.OpenSsl\",\"System.Collections\",\"System.Diagnostics.Debug\",\"System.Globalization\",\"System.Globalization.Calendars\",\"System.IO\",\"System.IO.FileSystem\",\"System.IO.FileSystem.Primitives\",\"System.Resources.ResourceManager\",\"System.Runtime\",\"System.Runtime.Extensions\",\"System.Runtime.Handles\",\"System.Runtime.InteropServices\",\"System.Runtime.Numerics\",\"System.Security.Cryptography.Algorithms\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Csp\",\"System.Security.Cryptography.Encoding\",\"System.Security.Cryptography.OpenSsl\",\"System.Security.Cryptography.Primitives\",\"System.Text.Encoding\",\"System.Threading\"]},\"framework_list\":[],\"id\":\"System.Security.Cryptography.X509Certificates\",\"sha512\":\"sha512-Ax8SNsw9NCe5pBEysVjrPiGgmcw9ToUMQyNOsbKL0BAGO3VQ+Gis2eleJ7KVmJ5j2gFdgh42yc9U2hboXdy+3A==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.2\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"System.Security.AccessControl\"],\"net462\":[\"System.Security.AccessControl\"],\"net47\":[\"System.Security.AccessControl\"],\"net471\":[\"System.Security.AccessControl\"],\"net472\":[\"System.Security.AccessControl\"],\"net48\":[\"System.Security.AccessControl\"],\"net5.0\":[\"System.Security.AccessControl\",\"System.Windows.Extensions\"],\"net6.0\":[\"System.Security.AccessControl\",\"System.Windows.Extensions\"],\"net7.0\":[\"System.Security.AccessControl\",\"System.Windows.Extensions\"],\"net8.0\":[\"System.Security.AccessControl\",\"System.Windows.Extensions\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"System.Security.AccessControl\"],\"netcoreapp2.1\":[\"System.Security.AccessControl\"],\"netcoreapp2.2\":[\"System.Security.AccessControl\"],\"netcoreapp3.0\":[\"System.Security.AccessControl\"],\"netcoreapp3.1\":[\"System.Security.AccessControl\",\"System.Windows.Extensions\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"System.Security.AccessControl\"],\"netstandard2.1\":[\"System.Security.AccessControl\"]},\"framework_list\":[],\"id\":\"System.Security.Permissions\",\"sha512\":\"sha512-1PIXLMOxZPEE+i46Mwti8qFfUOBQqRZZ21co8o1NXWyoZg7sOk+SIJAYGlS8Hp9mNMpJdQOYNgcn0bxZ22ICeA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.Text.Encoding\",\"sha512\":\"sha512-b/f+7HMTpxIfeV7H03bkuHKMFylCGfr9/U6gePnfFFW0aF8LOWLDgQCY6V1oWUqDksC3mdNuyChM1vy9TP4sZw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"Microsoft.Bcl.AsyncInterfaces\",\"System.Runtime.CompilerServices.Unsafe\"],\"net462\":[\"Microsoft.Bcl.AsyncInterfaces\",\"System.Runtime.CompilerServices.Unsafe\"],\"net47\":[\"Microsoft.Bcl.AsyncInterfaces\",\"System.Runtime.CompilerServices.Unsafe\"],\"net471\":[\"Microsoft.Bcl.AsyncInterfaces\",\"System.Runtime.CompilerServices.Unsafe\"],\"net472\":[\"Microsoft.Bcl.AsyncInterfaces\",\"System.Runtime.CompilerServices.Unsafe\"],\"net48\":[\"Microsoft.Bcl.AsyncInterfaces\",\"System.Runtime.CompilerServices.Unsafe\"],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"Microsoft.Bcl.AsyncInterfaces\",\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp2.1\":[\"Microsoft.Bcl.AsyncInterfaces\",\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp2.2\":[\"Microsoft.Bcl.AsyncInterfaces\",\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp3.0\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netcoreapp3.1\":[\"System.Runtime.CompilerServices.Unsafe\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"Microsoft.Bcl.AsyncInterfaces\",\"System.Runtime.CompilerServices.Unsafe\"],\"netstandard2.1\":[\"Microsoft.Bcl.AsyncInterfaces\",\"System.Runtime.CompilerServices.Unsafe\"]},\"framework_list\":[],\"id\":\"System.Text.Json\",\"sha512\":\"sha512-PTL4h2MLbKEqZ/9TE6SEmJp1txIh0GjzYPQrWGbfJ5sgbPrpXzb9sOoXe3cid51zDBE+2KCLd95e/04JiNr0TQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.0.2\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"net6.0\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"net7.0\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"net8.0\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netcoreapp1.0\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netcoreapp1.1\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netcoreapp2.0\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netcoreapp2.1\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netcoreapp2.2\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netcoreapp3.0\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netcoreapp3.1\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netstandard\":[],\"netstandard1.0\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netstandard1.1\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netstandard1.2\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netstandard1.3\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netstandard1.4\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netstandard1.5\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netstandard1.6\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netstandard2.0\":[\"System.Runtime\",\"System.Threading.Tasks\"],\"netstandard2.1\":[\"System.Runtime\",\"System.Threading.Tasks\"]},\"framework_list\":[],\"id\":\"System.Threading\",\"sha512\":\"sha512-l6J1G9zmn6r5xU+DSp/Vxgx6eG+qUvQgdpgo28m1gEwfNyG6HqlF6h2ESDXZCYEPnngsmkTQ+q7MyyMMTNlaiA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\",\"Microsoft.NETCore.Targets\",\"System.Runtime\"]},\"framework_list\":[],\"id\":\"System.Threading.Tasks\",\"sha512\":\"sha512-fUiP+CyyCjs872OA8trl6p97qma/da1xGq3h4zAbJZk8zyaU4zyEfqW5vbkP80xG/Nimun1vlWBboMEk7XxdEw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"4.3.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"System.Drawing.Common\"],\"net6.0\":[\"System.Drawing.Common\"],\"net7.0\":[\"System.Drawing.Common\"],\"net8.0\":[\"System.Drawing.Common\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[\"System.Drawing.Common\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Windows.Extensions\",\"sha512\":\"sha512-9R7sgWb5e1/OokgW7HN8JNXFpcsUXvLTMnfJoWBE9AvD+5e0z+f5ojr3BO3pFYbGq9Ks8AsndTi7ME13ocpU8A==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}"
+              ],
+              "targeting_pack_overrides": {
+                "argu": [],
+                "chessie": [],
+                "fsharp.control.asyncseq": [],
+                "fsharp.core": [],
+                "fsharp.systemtextjson": [],
+                "fsharpx.async": [],
+                "fsharpx.collections": [],
+                "fsharpx.extras": [],
+                "microsoft.bcl.asyncinterfaces": [],
+                "microsoft.csharp": [],
+                "microsoft.extensions.fileproviders.abstractions": [],
+                "microsoft.extensions.filesystemglobbing": [],
+                "microsoft.extensions.primitives": [],
+                "microsoft.netcore.app.ref": [
+                  "Microsoft.CSharp|4.4.0",
+                  "Microsoft.Win32.Primitives|4.3.0",
+                  "Microsoft.Win32.Registry|4.4.0",
+                  "runtime.debian.8-x64.runtime.native.System|4.3.0",
+                  "runtime.debian.8-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.debian.8-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.debian.8-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.debian.8-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "runtime.fedora.23-x64.runtime.native.System|4.3.0",
+                  "runtime.fedora.23-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.fedora.23-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.fedora.23-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "runtime.fedora.24-x64.runtime.native.System|4.3.0",
+                  "runtime.fedora.24-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.fedora.24-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.fedora.24-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "runtime.opensuse.13.2-x64.runtime.native.System|4.3.0",
+                  "runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.opensuse.13.2-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.opensuse.13.2-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "runtime.opensuse.42.1-x64.runtime.native.System|4.3.0",
+                  "runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.opensuse.42.1-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.opensuse.42.1-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "runtime.osx.10.10-x64.runtime.native.System|4.3.0",
+                  "runtime.osx.10.10-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.osx.10.10-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.osx.10.10-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple|4.3.0",
+                  "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "runtime.rhel.7-x64.runtime.native.System|4.3.0",
+                  "runtime.rhel.7-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.rhel.7-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.rhel.7-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "runtime.ubuntu.14.04-x64.runtime.native.System|4.3.0",
+                  "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "runtime.ubuntu.16.04-x64.runtime.native.System|4.3.0",
+                  "runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "runtime.ubuntu.16.10-x64.runtime.native.System|4.3.0",
+                  "runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "System.AppContext|4.3.0",
+                  "System.Buffers|4.4.0",
+                  "System.Collections|4.3.0",
+                  "System.Collections.Concurrent|4.3.0",
+                  "System.Collections.Immutable|1.4.0",
+                  "System.Collections.NonGeneric|4.3.0",
+                  "System.Collections.Specialized|4.3.0",
+                  "System.ComponentModel|4.3.0",
+                  "System.ComponentModel.EventBasedAsync|4.3.0",
+                  "System.ComponentModel.Primitives|4.3.0",
+                  "System.ComponentModel.TypeConverter|4.3.0",
+                  "System.Console|4.3.0",
+                  "System.Data.Common|4.3.0",
+                  "System.Diagnostics.Contracts|4.3.0",
+                  "System.Diagnostics.Debug|4.3.0",
+                  "System.Diagnostics.DiagnosticSource|4.4.0",
+                  "System.Diagnostics.FileVersionInfo|4.3.0",
+                  "System.Diagnostics.Process|4.3.0",
+                  "System.Diagnostics.StackTrace|4.3.0",
+                  "System.Diagnostics.TextWriterTraceListener|4.3.0",
+                  "System.Diagnostics.Tools|4.3.0",
+                  "System.Diagnostics.TraceSource|4.3.0",
+                  "System.Diagnostics.Tracing|4.3.0",
+                  "System.Dynamic.Runtime|4.3.0",
+                  "System.Globalization|4.3.0",
+                  "System.Globalization.Calendars|4.3.0",
+                  "System.Globalization.Extensions|4.3.0",
+                  "System.IO|4.3.0",
+                  "System.IO.Compression|4.3.0",
+                  "System.IO.Compression.ZipFile|4.3.0",
+                  "System.IO.FileSystem|4.3.0",
+                  "System.IO.FileSystem.AccessControl|4.4.0",
+                  "System.IO.FileSystem.DriveInfo|4.3.0",
+                  "System.IO.FileSystem.Primitives|4.3.0",
+                  "System.IO.FileSystem.Watcher|4.3.0",
+                  "System.IO.IsolatedStorage|4.3.0",
+                  "System.IO.MemoryMappedFiles|4.3.0",
+                  "System.IO.Pipes|4.3.0",
+                  "System.IO.UnmanagedMemoryStream|4.3.0",
+                  "System.Linq|4.3.0",
+                  "System.Linq.Expressions|4.3.0",
+                  "System.Linq.Queryable|4.3.0",
+                  "System.Net.Http|4.3.0",
+                  "System.Net.NameResolution|4.3.0",
+                  "System.Net.Primitives|4.3.0",
+                  "System.Net.Requests|4.3.0",
+                  "System.Net.Security|4.3.0",
+                  "System.Net.Sockets|4.3.0",
+                  "System.Net.WebHeaderCollection|4.3.0",
+                  "System.ObjectModel|4.3.0",
+                  "System.Private.DataContractSerialization|4.3.0",
+                  "System.Reflection|4.3.0",
+                  "System.Reflection.Emit|4.3.0",
+                  "System.Reflection.Emit.ILGeneration|4.3.0",
+                  "System.Reflection.Emit.Lightweight|4.3.0",
+                  "System.Reflection.Extensions|4.3.0",
+                  "System.Reflection.Metadata|1.5.0",
+                  "System.Reflection.Primitives|4.3.0",
+                  "System.Reflection.TypeExtensions|4.3.0",
+                  "System.Resources.ResourceManager|4.3.0",
+                  "System.Runtime|4.3.0",
+                  "System.Runtime.Extensions|4.3.0",
+                  "System.Runtime.Handles|4.3.0",
+                  "System.Runtime.InteropServices|4.3.0",
+                  "System.Runtime.InteropServices.RuntimeInformation|4.3.0",
+                  "System.Runtime.Loader|4.3.0",
+                  "System.Runtime.Numerics|4.3.0",
+                  "System.Runtime.Serialization.Formatters|4.3.0",
+                  "System.Runtime.Serialization.Json|4.3.0",
+                  "System.Runtime.Serialization.Primitives|4.3.0",
+                  "System.Security.AccessControl|4.4.0",
+                  "System.Security.Claims|4.3.0",
+                  "System.Security.Cryptography.Algorithms|4.3.0",
+                  "System.Security.Cryptography.Cng|4.4.0",
+                  "System.Security.Cryptography.Csp|4.3.0",
+                  "System.Security.Cryptography.Encoding|4.3.0",
+                  "System.Security.Cryptography.OpenSsl|4.4.0",
+                  "System.Security.Cryptography.Primitives|4.3.0",
+                  "System.Security.Cryptography.X509Certificates|4.3.0",
+                  "System.Security.Cryptography.Xml|4.4.0",
+                  "System.Security.Principal|4.3.0",
+                  "System.Security.Principal.Windows|4.4.0",
+                  "System.Text.Encoding|4.3.0",
+                  "System.Text.Encoding.Extensions|4.3.0",
+                  "System.Text.RegularExpressions|4.3.0",
+                  "System.Threading|4.3.0",
+                  "System.Threading.Overlapped|4.3.0",
+                  "System.Threading.Tasks|4.3.0",
+                  "System.Threading.Tasks.Extensions|4.3.0",
+                  "System.Threading.Tasks.Parallel|4.3.0",
+                  "System.Threading.Thread|4.3.0",
+                  "System.Threading.ThreadPool|4.3.0",
+                  "System.Threading.Timer|4.3.0",
+                  "System.ValueTuple|4.3.0",
+                  "System.Xml.ReaderWriter|4.3.0",
+                  "System.Xml.XDocument|4.3.0",
+                  "System.Xml.XmlDocument|4.3.0",
+                  "System.Xml.XmlSerializer|4.3.0",
+                  "System.Xml.XPath|4.3.0",
+                  "System.Xml.XPath.XDocument|4.3.0"
+                ],
+                "microsoft.netcore.platforms": [],
+                "microsoft.netcore.targets": [],
+                "microsoft.web.xdt": [],
+                "microsoft.win32.systemevents": [],
+                "mono.cecil": [],
+                "netstandard.library": [],
+                "newtonsoft.json": [],
+                "nuget.commands": [],
+                "nuget.common": [],
+                "nuget.configuration": [],
+                "nuget.credentials": [],
+                "nuget.dependencyresolver.core": [],
+                "nuget.frameworks": [],
+                "nuget.librarymodel": [],
+                "nuget.packagemanagement": [],
+                "nuget.packaging": [],
+                "nuget.projectmodel": [],
+                "nuget.protocol": [],
+                "nuget.resolver": [],
+                "nuget.versioning": [],
+                "paket.core": [],
+                "runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.debian.9-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.fedora.27-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.fedora.28-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.native.system": [],
+                "runtime.native.system.net.http": [],
+                "runtime.native.system.security.cryptography.apple": [],
+                "runtime.native.system.security.cryptography.openssl": [],
+                "runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.opensuse.42.3-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple": [],
+                "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.ubuntu.18.04-x64.runtime.native.system.security.cryptography.openssl": [],
+                "system.collections": [],
+                "system.collections.concurrent": [],
+                "system.componentmodel.composition": [],
+                "system.configuration.configurationmanager": [],
+                "system.diagnostics.debug": [],
+                "system.diagnostics.diagnosticsource": [],
+                "system.diagnostics.tracing": [],
+                "system.drawing.common": [],
+                "system.formats.asn1": [],
+                "system.globalization": [],
+                "system.globalization.calendars": [],
+                "system.globalization.extensions": [],
+                "system.io": [],
+                "system.io.filesystem": [],
+                "system.io.filesystem.primitives": [],
+                "system.linq": [],
+                "system.net.http": [],
+                "system.net.http.winhttphandler": [],
+                "system.net.primitives": [],
+                "system.reflection": [],
+                "system.reflection.emit.lightweight": [],
+                "system.reflection.primitives": [],
+                "system.resources.resourcemanager": [],
+                "system.runtime": [],
+                "system.runtime.compilerservices.unsafe": [],
+                "system.runtime.extensions": [],
+                "system.runtime.handles": [],
+                "system.runtime.interopservices": [],
+                "system.runtime.numerics": [],
+                "system.security.accesscontrol": [],
+                "system.security.cryptography.algorithms": [],
+                "system.security.cryptography.cng": [],
+                "system.security.cryptography.csp": [],
+                "system.security.cryptography.encoding": [],
+                "system.security.cryptography.openssl": [],
+                "system.security.cryptography.pkcs": [],
+                "system.security.cryptography.primitives": [],
+                "system.security.cryptography.protecteddata": [],
+                "system.security.cryptography.x509certificates": [],
+                "system.security.permissions": [],
+                "system.text.encoding": [],
+                "system.text.json": [],
+                "system.threading": [],
+                "system.threading.tasks": [],
+                "system.windows.extensions": []
+              },
+              "framework_list": {
+                "argu": [],
+                "chessie": [],
+                "fsharp.control.asyncseq": [],
+                "fsharp.core": [],
+                "fsharp.systemtextjson": [],
+                "fsharpx.async": [],
+                "fsharpx.collections": [],
+                "fsharpx.extras": [],
+                "microsoft.bcl.asyncinterfaces": [],
+                "microsoft.csharp": [],
+                "microsoft.extensions.fileproviders.abstractions": [],
+                "microsoft.extensions.filesystemglobbing": [],
+                "microsoft.extensions.primitives": [],
+                "microsoft.netcore.app.ref": [
+                  "Microsoft.CSharp|6.0.0.0",
+                  "Microsoft.VisualBasic.Core|11.0.0.0",
+                  "Microsoft.VisualBasic|10.0.0.0",
+                  "Microsoft.Win32.Primitives|6.0.0.0",
+                  "Microsoft.Win32.Registry|6.0.0.0",
+                  "System.AppContext|6.0.0.0",
+                  "System.Buffers|6.0.0.0",
+                  "System.Collections.Concurrent|6.0.0.0",
+                  "System.Collections.Immutable|6.0.0.0",
+                  "System.Collections.NonGeneric|6.0.0.0",
+                  "System.Collections.Specialized|6.0.0.0",
+                  "System.Collections|6.0.0.0",
+                  "System.ComponentModel.Annotations|6.0.0.0",
+                  "System.ComponentModel.DataAnnotations|4.0.0.0",
+                  "System.ComponentModel.EventBasedAsync|6.0.0.0",
+                  "System.ComponentModel.Primitives|6.0.0.0",
+                  "System.ComponentModel.TypeConverter|6.0.0.0",
+                  "System.ComponentModel|6.0.0.0",
+                  "System.Configuration|4.0.0.0",
+                  "System.Console|6.0.0.0",
+                  "System.Core|4.0.0.0",
+                  "System.Data.Common|6.0.0.0",
+                  "System.Data.DataSetExtensions|4.0.0.0",
+                  "System.Data|4.0.0.0",
+                  "System.Diagnostics.Contracts|6.0.0.0",
+                  "System.Diagnostics.Debug|6.0.0.0",
+                  "System.Diagnostics.DiagnosticSource|6.0.0.0",
+                  "System.Diagnostics.FileVersionInfo|6.0.0.0",
+                  "System.Diagnostics.Process|6.0.0.0",
+                  "System.Diagnostics.StackTrace|6.0.0.0",
+                  "System.Diagnostics.TextWriterTraceListener|6.0.0.0",
+                  "System.Diagnostics.Tools|6.0.0.0",
+                  "System.Diagnostics.TraceSource|6.0.0.0",
+                  "System.Diagnostics.Tracing|6.0.0.0",
+                  "System.Drawing.Primitives|6.0.0.0",
+                  "System.Drawing|4.0.0.0",
+                  "System.Dynamic.Runtime|6.0.0.0",
+                  "System.Formats.Asn1|6.0.0.0",
+                  "System.Globalization.Calendars|6.0.0.0",
+                  "System.Globalization.Extensions|6.0.0.0",
+                  "System.Globalization|6.0.0.0",
+                  "System.IO.Compression.Brotli|6.0.0.0",
+                  "System.IO.Compression.FileSystem|4.0.0.0",
+                  "System.IO.Compression.ZipFile|6.0.0.0",
+                  "System.IO.Compression|6.0.0.0",
+                  "System.IO.FileSystem.AccessControl|6.0.0.0",
+                  "System.IO.FileSystem.DriveInfo|6.0.0.0",
+                  "System.IO.FileSystem.Primitives|6.0.0.0",
+                  "System.IO.FileSystem.Watcher|6.0.0.0",
+                  "System.IO.FileSystem|6.0.0.0",
+                  "System.IO.IsolatedStorage|6.0.0.0",
+                  "System.IO.MemoryMappedFiles|6.0.0.0",
+                  "System.IO.Pipes.AccessControl|6.0.0.0",
+                  "System.IO.Pipes|6.0.0.0",
+                  "System.IO.UnmanagedMemoryStream|6.0.0.0",
+                  "System.IO|6.0.0.0",
+                  "System.Linq.Expressions|6.0.0.0",
+                  "System.Linq.Parallel|6.0.0.0",
+                  "System.Linq.Queryable|6.0.0.0",
+                  "System.Linq|6.0.0.0",
+                  "System.Memory|6.0.0.0",
+                  "System.Net.Http.Json|6.0.0.0",
+                  "System.Net.Http|6.0.0.0",
+                  "System.Net.HttpListener|6.0.0.0",
+                  "System.Net.Mail|6.0.0.0",
+                  "System.Net.NameResolution|6.0.0.0",
+                  "System.Net.NetworkInformation|6.0.0.0",
+                  "System.Net.Ping|6.0.0.0",
+                  "System.Net.Primitives|6.0.0.0",
+                  "System.Net.Requests|6.0.0.0",
+                  "System.Net.Security|6.0.0.0",
+                  "System.Net.ServicePoint|6.0.0.0",
+                  "System.Net.Sockets|6.0.0.0",
+                  "System.Net.WebClient|6.0.0.0",
+                  "System.Net.WebHeaderCollection|6.0.0.0",
+                  "System.Net.WebProxy|6.0.0.0",
+                  "System.Net.WebSockets.Client|6.0.0.0",
+                  "System.Net.WebSockets|6.0.0.0",
+                  "System.Net|4.0.0.0",
+                  "System.Numerics.Vectors|6.0.0.0",
+                  "System.Numerics|4.0.0.0",
+                  "System.ObjectModel|6.0.0.0",
+                  "System.Reflection.DispatchProxy|6.0.0.0",
+                  "System.Reflection.Emit.ILGeneration|6.0.0.0",
+                  "System.Reflection.Emit.Lightweight|6.0.0.0",
+                  "System.Reflection.Emit|6.0.0.0",
+                  "System.Reflection.Extensions|6.0.0.0",
+                  "System.Reflection.Metadata|6.0.0.0",
+                  "System.Reflection.Primitives|6.0.0.0",
+                  "System.Reflection.TypeExtensions|6.0.0.0",
+                  "System.Reflection|6.0.0.0",
+                  "System.Resources.Reader|6.0.0.0",
+                  "System.Resources.ResourceManager|6.0.0.0",
+                  "System.Resources.Writer|6.0.0.0",
+                  "System.Runtime.CompilerServices.Unsafe|6.0.0.0",
+                  "System.Runtime.CompilerServices.VisualC|6.0.0.0",
+                  "System.Runtime.Extensions|6.0.0.0",
+                  "System.Runtime.Handles|6.0.0.0",
+                  "System.Runtime.InteropServices.RuntimeInformation|6.0.0.0",
+                  "System.Runtime.InteropServices|6.0.0.0",
+                  "System.Runtime.Intrinsics|6.0.0.0",
+                  "System.Runtime.Loader|6.0.0.0",
+                  "System.Runtime.Numerics|6.0.0.0",
+                  "System.Runtime.Serialization.Formatters|6.0.0.0",
+                  "System.Runtime.Serialization.Json|6.0.0.0",
+                  "System.Runtime.Serialization.Primitives|6.0.0.0",
+                  "System.Runtime.Serialization.Xml|6.0.0.0",
+                  "System.Runtime.Serialization|4.0.0.0",
+                  "System.Runtime|6.0.0.0",
+                  "System.Security.AccessControl|6.0.0.0",
+                  "System.Security.Claims|6.0.0.0",
+                  "System.Security.Cryptography.Algorithms|6.0.0.0",
+                  "System.Security.Cryptography.Cng|6.0.0.0",
+                  "System.Security.Cryptography.Csp|6.0.0.0",
+                  "System.Security.Cryptography.Encoding|6.0.0.0",
+                  "System.Security.Cryptography.OpenSsl|6.0.0.0",
+                  "System.Security.Cryptography.Primitives|6.0.0.0",
+                  "System.Security.Cryptography.X509Certificates|6.0.0.0",
+                  "System.Security.Principal.Windows|6.0.0.0",
+                  "System.Security.Principal|6.0.0.0",
+                  "System.Security.SecureString|6.0.0.0",
+                  "System.Security|4.0.0.0",
+                  "System.ServiceModel.Web|4.0.0.0",
+                  "System.ServiceProcess|4.0.0.0",
+                  "System.Text.Encoding.CodePages|6.0.0.0",
+                  "System.Text.Encoding.Extensions|6.0.0.0",
+                  "System.Text.Encoding|6.0.0.0",
+                  "System.Text.Encodings.Web|6.0.0.0",
+                  "System.Text.Json|6.0.0.0",
+                  "System.Text.RegularExpressions|6.0.0.0",
+                  "System.Threading.Channels|6.0.0.0",
+                  "System.Threading.Overlapped|6.0.0.0",
+                  "System.Threading.Tasks.Dataflow|6.0.0.0",
+                  "System.Threading.Tasks.Extensions|6.0.0.0",
+                  "System.Threading.Tasks.Parallel|6.0.0.0",
+                  "System.Threading.Tasks|6.0.0.0",
+                  "System.Threading.Thread|6.0.0.0",
+                  "System.Threading.ThreadPool|6.0.0.0",
+                  "System.Threading.Timer|6.0.0.0",
+                  "System.Threading|6.0.0.0",
+                  "System.Transactions.Local|6.0.0.0",
+                  "System.Transactions|4.0.0.0",
+                  "System.ValueTuple|4.0.3.0",
+                  "System.Web.HttpUtility|6.0.0.0",
+                  "System.Web|4.0.0.0",
+                  "System.Windows|4.0.0.0",
+                  "System.Xml.Linq|4.0.0.0",
+                  "System.Xml.ReaderWriter|6.0.0.0",
+                  "System.Xml.Serialization|4.0.0.0",
+                  "System.Xml.XDocument|6.0.0.0",
+                  "System.Xml.XPath.XDocument|6.0.0.0",
+                  "System.Xml.XPath|6.0.0.0",
+                  "System.Xml.XmlDocument|6.0.0.0",
+                  "System.Xml.XmlSerializer|6.0.0.0",
+                  "System.Xml|4.0.0.0",
+                  "System|4.0.0.0",
+                  "WindowsBase|4.0.0.0",
+                  "mscorlib|4.0.0.0",
+                  "netstandard|2.1.0.0"
+                ],
+                "microsoft.netcore.platforms": [],
+                "microsoft.netcore.targets": [],
+                "microsoft.web.xdt": [],
+                "microsoft.win32.systemevents": [],
+                "mono.cecil": [],
+                "netstandard.library": [],
+                "newtonsoft.json": [],
+                "nuget.commands": [],
+                "nuget.common": [],
+                "nuget.configuration": [],
+                "nuget.credentials": [],
+                "nuget.dependencyresolver.core": [],
+                "nuget.frameworks": [],
+                "nuget.librarymodel": [],
+                "nuget.packagemanagement": [],
+                "nuget.packaging": [],
+                "nuget.projectmodel": [],
+                "nuget.protocol": [],
+                "nuget.resolver": [],
+                "nuget.versioning": [],
+                "paket.core": [],
+                "runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.debian.9-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.fedora.27-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.fedora.28-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.native.system": [],
+                "runtime.native.system.net.http": [],
+                "runtime.native.system.security.cryptography.apple": [],
+                "runtime.native.system.security.cryptography.openssl": [],
+                "runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.opensuse.42.3-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple": [],
+                "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl": [],
+                "runtime.ubuntu.18.04-x64.runtime.native.system.security.cryptography.openssl": [],
+                "system.collections": [],
+                "system.collections.concurrent": [],
+                "system.componentmodel.composition": [],
+                "system.configuration.configurationmanager": [],
+                "system.diagnostics.debug": [],
+                "system.diagnostics.diagnosticsource": [],
+                "system.diagnostics.tracing": [],
+                "system.drawing.common": [],
+                "system.formats.asn1": [],
+                "system.globalization": [],
+                "system.globalization.calendars": [],
+                "system.globalization.extensions": [],
+                "system.io": [],
+                "system.io.filesystem": [],
+                "system.io.filesystem.primitives": [],
+                "system.linq": [],
+                "system.net.http": [],
+                "system.net.http.winhttphandler": [],
+                "system.net.primitives": [],
+                "system.reflection": [],
+                "system.reflection.emit.lightweight": [],
+                "system.reflection.primitives": [],
+                "system.resources.resourcemanager": [],
+                "system.runtime": [],
+                "system.runtime.compilerservices.unsafe": [],
+                "system.runtime.extensions": [],
+                "system.runtime.handles": [],
+                "system.runtime.interopservices": [],
+                "system.runtime.numerics": [],
+                "system.security.accesscontrol": [],
+                "system.security.cryptography.algorithms": [],
+                "system.security.cryptography.cng": [],
+                "system.security.cryptography.csp": [],
+                "system.security.cryptography.encoding": [],
+                "system.security.cryptography.openssl": [],
+                "system.security.cryptography.pkcs": [],
+                "system.security.cryptography.primitives": [],
+                "system.security.cryptography.protecteddata": [],
+                "system.security.cryptography.x509certificates": [],
+                "system.security.permissions": [],
+                "system.text.encoding": [],
+                "system.text.json": [],
+                "system.threading": [],
+                "system.threading.tasks": [],
+                "system.windows.extensions": []
+              }
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_dotnet+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "rules_dotnet+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_dotnet+",
+            "rules_dotnet",
+            "rules_dotnet+"
+          ]
+        ]
+      }
+    },
+    "@@rules_dotnet+//dotnet:paket.rules_dotnet_nuget_packages_extension.bzl%rules_dotnet_nuget_packages_extension": {
+      "general": {
+        "bzlTransitiveDigest": "rB6WNMow7J14Mi1Vlo0OGUV4jUhn/z+wi56RRbgMjTw=",
+        "usagesDigest": "k/st7Gv6cOoXf48TERH77CT0otg817eM0yMATo2Ekzs=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "nuget.mcmaster.extensions.commandlineutils.v2.5.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "mcmaster.extensions.commandlineutils",
+              "version": "2.5.0",
+              "sha512": "sha512-00uJOWYKPCPqDB6RxyOLXNnoPGeRmzKTZhu5OdZJaWn5+JV/n6mzB3/M+Z1yMpkabag3Lym9S11G/ITLrptOiw=="
+            }
+          },
+          "nuget.microsoft.netcore.app.ref.v6.0.5": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "microsoft.netcore.app.ref",
+              "version": "6.0.5",
+              "sha512": "sha512-quj/gyLoZLypJO7PwsZ8ib6ZSgFv1C9s5SJgwzl/gztynTJ/3oO/stA2gNMf0C33vTJ0J3SSF/kRPQ/ifY5xZg=="
+            }
+          },
+          "nuget.microsoft.netcore.platforms.v6.0.5": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "microsoft.netcore.platforms",
+              "version": "6.0.5",
+              "sha512": "sha512-GTMT/dgCRBCRUj11ssZ8K1FJm6Md+C/tSJl8I7YjxOFwSvopaIneV32y1VlnBTI4wy1SwueI7ou2sVfHkWENrA=="
+            }
+          },
+          "nuget.microsoft.web.xdt.v3.1.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "microsoft.web.xdt",
+              "version": "3.1.0",
+              "sha512": "sha512-3VApgkdgOglJWtrXSgYzz6o8Cp6IpvmFQMeICyQvvbKoy+OjNwco5ovzBBL1HHj7kEgLfe2ruXW/ZQ1k+2YxYw=="
+            }
+          },
+          "nuget.netstandard.library.v2.0.3": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "netstandard.library",
+              "version": "2.0.3",
+              "sha512": "sha512-548M6mnBSJWxsIlkQHfbzoYxpiYFXZZSL00p4GHYv8PkiqFBnnT68mW5mGEsA/ch9fDO9GkPgkFQpWiXZN7mAQ=="
+            }
+          },
+          "nuget.netstandard.library.ref.v2.1.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "netstandard.library.ref",
+              "version": "2.1.0",
+              "sha512": "sha512-Jr0OqnqkaJJGEVq3w9oNQrIEteD/4QBNg3YOh1cvRjydzwop07+5aWjO/SfEYu6CwBn+dSBKXj8niEvTNy2brA=="
+            }
+          },
+          "nuget.newtonsoft.json.v13.0.1": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "newtonsoft.json",
+              "version": "13.0.1",
+              "sha512": "sha512-g3MbZi6vBTeaI/hEbvR7vBETSd1DWLe9i1E4P+nPY34v5i94zqUqDXvdWC3G+7tYN9SnsdU9zzegrnRz4h7nsQ=="
+            }
+          },
+          "nuget.nuget.commands.v5.10.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.commands",
+              "version": "5.10.0",
+              "sha512": "sha512-Q7ANXnmLUPC4pWgCZjBy2R7vRDABiaJz5NsBtoErE0dLylx/zQWRMyoa+m4Y478SKvUpt7S1V7LhAOlMRCTPpg=="
+            }
+          },
+          "nuget.nuget.common.v5.10.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.common",
+              "version": "5.10.0",
+              "sha512": "sha512-8M9VtXAB1M15KmvL0F9QsItI96PH3WmYD0z3oxYm5H9G5AIhK8Ivi4kGzqtBJDTsZ/NkP91U1MnoCAeg4E4+zA=="
+            }
+          },
+          "nuget.nuget.configuration.v5.10.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.configuration",
+              "version": "5.10.0",
+              "sha512": "sha512-ZJc2HY/D+UEk2U0jxamyBhUbKl2bgluViM/tnP4ObIIfJpOj8dHEJ6xzggulIGDlhe+ItK6yc+sqtCb6qV5+gw=="
+            }
+          },
+          "nuget.nuget.credentials.v5.10.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.credentials",
+              "version": "5.10.0",
+              "sha512": "sha512-r/fzn5yJaCXyChbhxbGZ5d/4xV4n3NIjVdE3odLfQy0znmcYRCDIfjYGu5l7vO9Nx27F+q7YA+9QmG9sucxX9A=="
+            }
+          },
+          "nuget.nuget.dependencyresolver.core.v5.10.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.dependencyresolver.core",
+              "version": "5.10.0",
+              "sha512": "sha512-+9mCFiBhnm5C2Cb3dtHaHyv/WarSr5HwRi2NaoVJgudpHoK3B9uy8wB7PNnUos0kOghZmVslemeLsmw7icQqTw=="
+            }
+          },
+          "nuget.nuget.frameworks.v5.10.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.frameworks",
+              "version": "5.10.0",
+              "sha512": "sha512-l8KtHN2bzA391seLZ9Q2AWK0mbCHpfbwL1nmOSMDxBpWLxqh+nxMWaKL437bROpHltU+oP5LX/hc4Fxm89T9Tg=="
+            }
+          },
+          "nuget.nuget.librarymodel.v5.10.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.librarymodel",
+              "version": "5.10.0",
+              "sha512": "sha512-xb8XLKJEMymZMAZJeXdSUaDNFRQMJ4MXkOPUaqafcgSKGz8M8BZgfLsBz9QCQVEyHIVYGbI4yroWZYed/c8xSg=="
+            }
+          },
+          "nuget.nuget.packagemanagement.v5.10.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.packagemanagement",
+              "version": "5.10.0",
+              "sha512": "sha512-Kr0CZuStXNsJRL86ecuWGhIHUhYy31rYZJ9WZ0tiFUaRwiPb7HpSQVsV/v3tqrKE7FWUZBpasX1bugXNqXcPjA=="
+            }
+          },
+          "nuget.nuget.packaging.v5.10.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.packaging",
+              "version": "5.10.0",
+              "sha512": "sha512-2HMq5gNgLMOHmqGb84pyEC7ctkCYBVXkhJfcYmHlkpo4FpDA6GQBoT//1h0Q4nGoybtgoBxiIbJu8VRn/9CZrQ=="
+            }
+          },
+          "nuget.nuget.packaging.core.v5.10.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.packaging.core",
+              "version": "5.10.0",
+              "sha512": "sha512-/WXGAbLb4T0pwEfEeY0j8zOVpS36OHNUANL95txANysbLoG7tUr9e+5je+Nfh3iIqzMaHIZXT6JKFvHOBwAotw=="
+            }
+          },
+          "nuget.nuget.projectmodel.v5.10.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.projectmodel",
+              "version": "5.10.0",
+              "sha512": "sha512-gsZS2Kuat3ZjjPcBQ3Mc8QlRv6mP1OzNzkF4Dzybu3LgtG+kwvgQh4UMLbiIrko6WKbwVTbr8nQYpL+wsVZ4hA=="
+            }
+          },
+          "nuget.nuget.protocol.v5.10.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.protocol",
+              "version": "5.10.0",
+              "sha512": "sha512-lY85Pgf7kr0JwTufdJmfDgBwN9BRQc96F4xxKrUGSALhuZRRC7y6f2RN1JQ0UTPIXlQx7HTG/h0UZEknQj3/UQ=="
+            }
+          },
+          "nuget.nuget.resolver.v5.10.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.resolver",
+              "version": "5.10.0",
+              "sha512": "sha512-a2zWl9RkKDkcVUqfRJjz3O4uoPIWf3PGaFf6AntXtTKjvvsB6SZz8jjPSGdLgTTRIWzsFlybKp6yU+GaXeIQkg=="
+            }
+          },
+          "nuget.nuget.versioning.v5.10.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nuget.versioning",
+              "version": "5.10.0",
+              "sha512": "sha512-NW11tfXijCWeI8d71HKpNPKPzJqr30PtUyJHzCpKFMFTGZhsHh2YxgjKBuhpC5R59SMZUzqrFF5CgJ8uGaupqg=="
+            }
+          },
+          "nuget.nunit.v3.12.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nunit",
+              "version": "3.12.0",
+              "sha512": "sha512-HAhwFxr+Z+PJf8hXzc747NecvsDwEZ+3X8SA5+GIRM43GAy1Ap+TQPMHsWCnisfes5vPZ1/a2md/91u+shoTsQ=="
+            }
+          },
+          "nuget.nunitlite.v3.12.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "nunitlite",
+              "version": "3.12.0",
+              "sha512": "sha512-M9VVS4x3KURXFS4HTl2b7uJOX7vOi2wzpHACmNX6ANlBmb0/hIehJLciiVvddD3ubIIL81EF4Qk54kpsUOtVFQ=="
+            }
+          },
+          "nuget.system.componentmodel.annotations.v5.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.componentmodel.annotations",
+              "version": "5.0.0",
+              "sha512": "sha512-WJqsTGaXAc55EPGjJylPFXiNPs/x1t9dklVlHlIBxUEcIxIob6sRGm9Un7TehkyEFM+vKjZd7rbwaMH/znw1PA=="
+            }
+          },
+          "nuget.system.componentmodel.composition.v6.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.componentmodel.composition",
+              "version": "6.0.0",
+              "sha512": "sha512-YWQ3ENu0D2st9ZV+Yj4u3IFcas0Pw7S4c7ymDUooPLb1psNJ53YniX2orSiY2OlRWnssaUsTytnVJa/KfCn5aA=="
+            }
+          },
+          "nuget.system.formats.asn1.v6.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.formats.asn1",
+              "version": "6.0.0",
+              "sha512": "sha512-62YP6zLnvmFtFI3rjybbrnSeK6hHQCaFfJJfoNhQqrETJBPehSucQxIyQs5W+GGBW/rpSXD/0NqNW7mttIWXhA=="
+            }
+          },
+          "nuget.system.security.cryptography.cng.v5.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.cryptography.cng",
+              "version": "5.0.0",
+              "sha512": "sha512-trvkAklUhzM+/z9bPnGmDLzmbvD0l1IlC6gpFRpzjGLylTgtTPqm8Uv7tnDBTuBQObjEZBxNS0bChIi6zQCV9w=="
+            }
+          },
+          "nuget.system.security.cryptography.pkcs.v6.0.1": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.cryptography.pkcs",
+              "version": "6.0.1",
+              "sha512": "sha512-ubxxZt0n9t8Xe/NtN53XMf6ZSfRKsk/T+mheDuoZbYrBJRLVyQ4pecXoROihl/DyC9uVOt6QrejwLAx1Raj1wg=="
+            }
+          },
+          "nuget.system.security.cryptography.protecteddata.v6.0.0": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_archive.bzl%nuget_archive",
+            "attributes": {
+              "sources": [
+                "https://api.nuget.org/v3/index.json"
+              ],
+              "id": "system.security.cryptography.protecteddata",
+              "version": "6.0.0",
+              "sha512": "sha512-SJtdqwq/rfuLwtBDfeg6FEeRgHGUlEDnZttwHIHDUY3mo4o+D2mXBrBtWRq1OTx7wLLqqBwVv/FWM5JI5sNXMA=="
+            }
+          },
+          "paket.rules_dotnet_nuget_packages": {
+            "repoRuleId": "@@rules_dotnet+//dotnet/private/rules/nuget:nuget_repo.bzl%_nuget_repo",
+            "attributes": {
+              "repo_name": "paket.rules_dotnet_nuget_packages",
+              "packages": [
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"System.ComponentModel.Annotations\"],\"net6.0\":[\"System.ComponentModel.Annotations\"],\"net7.0\":[\"System.ComponentModel.Annotations\"],\"net8.0\":[\"System.ComponentModel.Annotations\"],\"netcoreapp1.0\":[\"System.ComponentModel.Annotations\"],\"netcoreapp1.1\":[\"System.ComponentModel.Annotations\"],\"netcoreapp2.0\":[\"System.ComponentModel.Annotations\"],\"netcoreapp2.1\":[\"System.ComponentModel.Annotations\"],\"netcoreapp2.2\":[\"System.ComponentModel.Annotations\"],\"netcoreapp3.0\":[\"System.ComponentModel.Annotations\"],\"netcoreapp3.1\":[\"System.ComponentModel.Annotations\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[\"System.ComponentModel.Annotations\"],\"netstandard2.0\":[\"System.ComponentModel.Annotations\"],\"netstandard2.1\":[\"System.ComponentModel.Annotations\"]},\"framework_list\":[],\"id\":\"McMaster.Extensions.CommandLineUtils\",\"sha512\":\"sha512-00uJOWYKPCPqDB6RxyOLXNnoPGeRmzKTZhu5OdZJaWn5+JV/n6mzB3/M+Z1yMpkabag3Lym9S11G/ITLrptOiw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"2.5.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[\"Microsoft.CSharp|6.0.0.0\",\"Microsoft.VisualBasic.Core|11.0.0.0\",\"Microsoft.VisualBasic|10.0.0.0\",\"Microsoft.Win32.Primitives|6.0.0.0\",\"Microsoft.Win32.Registry|6.0.0.0\",\"System.AppContext|6.0.0.0\",\"System.Buffers|6.0.0.0\",\"System.Collections.Concurrent|6.0.0.0\",\"System.Collections.Immutable|6.0.0.0\",\"System.Collections.NonGeneric|6.0.0.0\",\"System.Collections.Specialized|6.0.0.0\",\"System.Collections|6.0.0.0\",\"System.ComponentModel.Annotations|6.0.0.0\",\"System.ComponentModel.DataAnnotations|4.0.0.0\",\"System.ComponentModel.EventBasedAsync|6.0.0.0\",\"System.ComponentModel.Primitives|6.0.0.0\",\"System.ComponentModel.TypeConverter|6.0.0.0\",\"System.ComponentModel|6.0.0.0\",\"System.Configuration|4.0.0.0\",\"System.Console|6.0.0.0\",\"System.Core|4.0.0.0\",\"System.Data.Common|6.0.0.0\",\"System.Data.DataSetExtensions|4.0.0.0\",\"System.Data|4.0.0.0\",\"System.Diagnostics.Contracts|6.0.0.0\",\"System.Diagnostics.Debug|6.0.0.0\",\"System.Diagnostics.DiagnosticSource|6.0.0.0\",\"System.Diagnostics.FileVersionInfo|6.0.0.0\",\"System.Diagnostics.Process|6.0.0.0\",\"System.Diagnostics.StackTrace|6.0.0.0\",\"System.Diagnostics.TextWriterTraceListener|6.0.0.0\",\"System.Diagnostics.Tools|6.0.0.0\",\"System.Diagnostics.TraceSource|6.0.0.0\",\"System.Diagnostics.Tracing|6.0.0.0\",\"System.Drawing.Primitives|6.0.0.0\",\"System.Drawing|4.0.0.0\",\"System.Dynamic.Runtime|6.0.0.0\",\"System.Formats.Asn1|6.0.0.0\",\"System.Globalization.Calendars|6.0.0.0\",\"System.Globalization.Extensions|6.0.0.0\",\"System.Globalization|6.0.0.0\",\"System.IO.Compression.Brotli|6.0.0.0\",\"System.IO.Compression.FileSystem|4.0.0.0\",\"System.IO.Compression.ZipFile|6.0.0.0\",\"System.IO.Compression|6.0.0.0\",\"System.IO.FileSystem.AccessControl|6.0.0.0\",\"System.IO.FileSystem.DriveInfo|6.0.0.0\",\"System.IO.FileSystem.Primitives|6.0.0.0\",\"System.IO.FileSystem.Watcher|6.0.0.0\",\"System.IO.FileSystem|6.0.0.0\",\"System.IO.IsolatedStorage|6.0.0.0\",\"System.IO.MemoryMappedFiles|6.0.0.0\",\"System.IO.Pipes.AccessControl|6.0.0.0\",\"System.IO.Pipes|6.0.0.0\",\"System.IO.UnmanagedMemoryStream|6.0.0.0\",\"System.IO|6.0.0.0\",\"System.Linq.Expressions|6.0.0.0\",\"System.Linq.Parallel|6.0.0.0\",\"System.Linq.Queryable|6.0.0.0\",\"System.Linq|6.0.0.0\",\"System.Memory|6.0.0.0\",\"System.Net.Http.Json|6.0.0.0\",\"System.Net.Http|6.0.0.0\",\"System.Net.HttpListener|6.0.0.0\",\"System.Net.Mail|6.0.0.0\",\"System.Net.NameResolution|6.0.0.0\",\"System.Net.NetworkInformation|6.0.0.0\",\"System.Net.Ping|6.0.0.0\",\"System.Net.Primitives|6.0.0.0\",\"System.Net.Requests|6.0.0.0\",\"System.Net.Security|6.0.0.0\",\"System.Net.ServicePoint|6.0.0.0\",\"System.Net.Sockets|6.0.0.0\",\"System.Net.WebClient|6.0.0.0\",\"System.Net.WebHeaderCollection|6.0.0.0\",\"System.Net.WebProxy|6.0.0.0\",\"System.Net.WebSockets.Client|6.0.0.0\",\"System.Net.WebSockets|6.0.0.0\",\"System.Net|4.0.0.0\",\"System.Numerics.Vectors|6.0.0.0\",\"System.Numerics|4.0.0.0\",\"System.ObjectModel|6.0.0.0\",\"System.Reflection.DispatchProxy|6.0.0.0\",\"System.Reflection.Emit.ILGeneration|6.0.0.0\",\"System.Reflection.Emit.Lightweight|6.0.0.0\",\"System.Reflection.Emit|6.0.0.0\",\"System.Reflection.Extensions|6.0.0.0\",\"System.Reflection.Metadata|6.0.0.0\",\"System.Reflection.Primitives|6.0.0.0\",\"System.Reflection.TypeExtensions|6.0.0.0\",\"System.Reflection|6.0.0.0\",\"System.Resources.Reader|6.0.0.0\",\"System.Resources.ResourceManager|6.0.0.0\",\"System.Resources.Writer|6.0.0.0\",\"System.Runtime.CompilerServices.Unsafe|6.0.0.0\",\"System.Runtime.CompilerServices.VisualC|6.0.0.0\",\"System.Runtime.Extensions|6.0.0.0\",\"System.Runtime.Handles|6.0.0.0\",\"System.Runtime.InteropServices.RuntimeInformation|6.0.0.0\",\"System.Runtime.InteropServices|6.0.0.0\",\"System.Runtime.Intrinsics|6.0.0.0\",\"System.Runtime.Loader|6.0.0.0\",\"System.Runtime.Numerics|6.0.0.0\",\"System.Runtime.Serialization.Formatters|6.0.0.0\",\"System.Runtime.Serialization.Json|6.0.0.0\",\"System.Runtime.Serialization.Primitives|6.0.0.0\",\"System.Runtime.Serialization.Xml|6.0.0.0\",\"System.Runtime.Serialization|4.0.0.0\",\"System.Runtime|6.0.0.0\",\"System.Security.AccessControl|6.0.0.0\",\"System.Security.Claims|6.0.0.0\",\"System.Security.Cryptography.Algorithms|6.0.0.0\",\"System.Security.Cryptography.Cng|6.0.0.0\",\"System.Security.Cryptography.Csp|6.0.0.0\",\"System.Security.Cryptography.Encoding|6.0.0.0\",\"System.Security.Cryptography.OpenSsl|6.0.0.0\",\"System.Security.Cryptography.Primitives|6.0.0.0\",\"System.Security.Cryptography.X509Certificates|6.0.0.0\",\"System.Security.Principal.Windows|6.0.0.0\",\"System.Security.Principal|6.0.0.0\",\"System.Security.SecureString|6.0.0.0\",\"System.Security|4.0.0.0\",\"System.ServiceModel.Web|4.0.0.0\",\"System.ServiceProcess|4.0.0.0\",\"System.Text.Encoding.CodePages|6.0.0.0\",\"System.Text.Encoding.Extensions|6.0.0.0\",\"System.Text.Encoding|6.0.0.0\",\"System.Text.Encodings.Web|6.0.0.0\",\"System.Text.Json|6.0.0.0\",\"System.Text.RegularExpressions|6.0.0.0\",\"System.Threading.Channels|6.0.0.0\",\"System.Threading.Overlapped|6.0.0.0\",\"System.Threading.Tasks.Dataflow|6.0.0.0\",\"System.Threading.Tasks.Extensions|6.0.0.0\",\"System.Threading.Tasks.Parallel|6.0.0.0\",\"System.Threading.Tasks|6.0.0.0\",\"System.Threading.Thread|6.0.0.0\",\"System.Threading.ThreadPool|6.0.0.0\",\"System.Threading.Timer|6.0.0.0\",\"System.Threading|6.0.0.0\",\"System.Transactions.Local|6.0.0.0\",\"System.Transactions|4.0.0.0\",\"System.ValueTuple|4.0.3.0\",\"System.Web.HttpUtility|6.0.0.0\",\"System.Web|4.0.0.0\",\"System.Windows|4.0.0.0\",\"System.Xml.Linq|4.0.0.0\",\"System.Xml.ReaderWriter|6.0.0.0\",\"System.Xml.Serialization|4.0.0.0\",\"System.Xml.XDocument|6.0.0.0\",\"System.Xml.XPath.XDocument|6.0.0.0\",\"System.Xml.XPath|6.0.0.0\",\"System.Xml.XmlDocument|6.0.0.0\",\"System.Xml.XmlSerializer|6.0.0.0\",\"System.Xml|4.0.0.0\",\"System|4.0.0.0\",\"WindowsBase|4.0.0.0\",\"mscorlib|4.0.0.0\",\"netstandard|2.1.0.0\"],\"id\":\"Microsoft.NETCore.App.Ref\",\"sha512\":\"sha512-quj/gyLoZLypJO7PwsZ8ib6ZSgFv1C9s5SJgwzl/gztynTJ/3oO/stA2gNMf0C33vTJ0J3SSF/kRPQ/ifY5xZg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[\"Microsoft.CSharp|4.4.0\",\"Microsoft.Win32.Primitives|4.3.0\",\"Microsoft.Win32.Registry|4.4.0\",\"runtime.debian.8-x64.runtime.native.System|4.3.0\",\"runtime.debian.8-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.debian.8-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.debian.8-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"runtime.fedora.23-x64.runtime.native.System|4.3.0\",\"runtime.fedora.23-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.fedora.23-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.fedora.23-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"runtime.fedora.24-x64.runtime.native.System|4.3.0\",\"runtime.fedora.24-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.fedora.24-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.fedora.24-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"runtime.opensuse.13.2-x64.runtime.native.System|4.3.0\",\"runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.opensuse.13.2-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.opensuse.13.2-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"runtime.opensuse.42.1-x64.runtime.native.System|4.3.0\",\"runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.opensuse.42.1-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.opensuse.42.1-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"runtime.osx.10.10-x64.runtime.native.System|4.3.0\",\"runtime.osx.10.10-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.osx.10.10-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.osx.10.10-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple|4.3.0\",\"runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"runtime.rhel.7-x64.runtime.native.System|4.3.0\",\"runtime.rhel.7-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.rhel.7-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.rhel.7-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"runtime.ubuntu.14.04-x64.runtime.native.System|4.3.0\",\"runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"runtime.ubuntu.16.04-x64.runtime.native.System|4.3.0\",\"runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"runtime.ubuntu.16.10-x64.runtime.native.System|4.3.0\",\"runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression|4.3.0\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http|4.3.0\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Net.Security|4.3.0\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography|4.3.0\",\"runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0\",\"System.AppContext|4.3.0\",\"System.Buffers|4.4.0\",\"System.Collections|4.3.0\",\"System.Collections.Concurrent|4.3.0\",\"System.Collections.Immutable|1.4.0\",\"System.Collections.NonGeneric|4.3.0\",\"System.Collections.Specialized|4.3.0\",\"System.ComponentModel|4.3.0\",\"System.ComponentModel.EventBasedAsync|4.3.0\",\"System.ComponentModel.Primitives|4.3.0\",\"System.ComponentModel.TypeConverter|4.3.0\",\"System.Console|4.3.0\",\"System.Data.Common|4.3.0\",\"System.Diagnostics.Contracts|4.3.0\",\"System.Diagnostics.Debug|4.3.0\",\"System.Diagnostics.DiagnosticSource|4.4.0\",\"System.Diagnostics.FileVersionInfo|4.3.0\",\"System.Diagnostics.Process|4.3.0\",\"System.Diagnostics.StackTrace|4.3.0\",\"System.Diagnostics.TextWriterTraceListener|4.3.0\",\"System.Diagnostics.Tools|4.3.0\",\"System.Diagnostics.TraceSource|4.3.0\",\"System.Diagnostics.Tracing|4.3.0\",\"System.Dynamic.Runtime|4.3.0\",\"System.Globalization|4.3.0\",\"System.Globalization.Calendars|4.3.0\",\"System.Globalization.Extensions|4.3.0\",\"System.IO|4.3.0\",\"System.IO.Compression|4.3.0\",\"System.IO.Compression.ZipFile|4.3.0\",\"System.IO.FileSystem|4.3.0\",\"System.IO.FileSystem.AccessControl|4.4.0\",\"System.IO.FileSystem.DriveInfo|4.3.0\",\"System.IO.FileSystem.Primitives|4.3.0\",\"System.IO.FileSystem.Watcher|4.3.0\",\"System.IO.IsolatedStorage|4.3.0\",\"System.IO.MemoryMappedFiles|4.3.0\",\"System.IO.Pipes|4.3.0\",\"System.IO.UnmanagedMemoryStream|4.3.0\",\"System.Linq|4.3.0\",\"System.Linq.Expressions|4.3.0\",\"System.Linq.Queryable|4.3.0\",\"System.Net.Http|4.3.0\",\"System.Net.NameResolution|4.3.0\",\"System.Net.Primitives|4.3.0\",\"System.Net.Requests|4.3.0\",\"System.Net.Security|4.3.0\",\"System.Net.Sockets|4.3.0\",\"System.Net.WebHeaderCollection|4.3.0\",\"System.ObjectModel|4.3.0\",\"System.Private.DataContractSerialization|4.3.0\",\"System.Reflection|4.3.0\",\"System.Reflection.Emit|4.3.0\",\"System.Reflection.Emit.ILGeneration|4.3.0\",\"System.Reflection.Emit.Lightweight|4.3.0\",\"System.Reflection.Extensions|4.3.0\",\"System.Reflection.Metadata|1.5.0\",\"System.Reflection.Primitives|4.3.0\",\"System.Reflection.TypeExtensions|4.3.0\",\"System.Resources.ResourceManager|4.3.0\",\"System.Runtime|4.3.0\",\"System.Runtime.Extensions|4.3.0\",\"System.Runtime.Handles|4.3.0\",\"System.Runtime.InteropServices|4.3.0\",\"System.Runtime.InteropServices.RuntimeInformation|4.3.0\",\"System.Runtime.Loader|4.3.0\",\"System.Runtime.Numerics|4.3.0\",\"System.Runtime.Serialization.Formatters|4.3.0\",\"System.Runtime.Serialization.Json|4.3.0\",\"System.Runtime.Serialization.Primitives|4.3.0\",\"System.Security.AccessControl|4.4.0\",\"System.Security.Claims|4.3.0\",\"System.Security.Cryptography.Algorithms|4.3.0\",\"System.Security.Cryptography.Cng|4.4.0\",\"System.Security.Cryptography.Csp|4.3.0\",\"System.Security.Cryptography.Encoding|4.3.0\",\"System.Security.Cryptography.OpenSsl|4.4.0\",\"System.Security.Cryptography.Primitives|4.3.0\",\"System.Security.Cryptography.X509Certificates|4.3.0\",\"System.Security.Cryptography.Xml|4.4.0\",\"System.Security.Principal|4.3.0\",\"System.Security.Principal.Windows|4.4.0\",\"System.Text.Encoding|4.3.0\",\"System.Text.Encoding.Extensions|4.3.0\",\"System.Text.RegularExpressions|4.3.0\",\"System.Threading|4.3.0\",\"System.Threading.Overlapped|4.3.0\",\"System.Threading.Tasks|4.3.0\",\"System.Threading.Tasks.Extensions|4.3.0\",\"System.Threading.Tasks.Parallel|4.3.0\",\"System.Threading.Thread|4.3.0\",\"System.Threading.ThreadPool|4.3.0\",\"System.Threading.Timer|4.3.0\",\"System.ValueTuple|4.3.0\",\"System.Xml.ReaderWriter|4.3.0\",\"System.Xml.XDocument|4.3.0\",\"System.Xml.XmlDocument|4.3.0\",\"System.Xml.XmlSerializer|4.3.0\",\"System.Xml.XPath|4.3.0\",\"System.Xml.XPath.XDocument|4.3.0\"],\"version\":\"6.0.5\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Microsoft.NETCore.Platforms\",\"sha512\":\"sha512-GTMT/dgCRBCRUj11ssZ8K1FJm6Md+C/tSJl8I7YjxOFwSvopaIneV32y1VlnBTI4wy1SwueI7ou2sVfHkWENrA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.5\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Microsoft.Web.Xdt\",\"sha512\":\"sha512-3VApgkdgOglJWtrXSgYzz6o8Cp6IpvmFQMeICyQvvbKoy+OjNwco5ovzBBL1HHj7kEgLfe2ruXW/ZQ1k+2YxYw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"3.1.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[\"Microsoft.NETCore.Platforms\"],\"net451\":[\"Microsoft.NETCore.Platforms\"],\"net452\":[\"Microsoft.NETCore.Platforms\"],\"net46\":[\"Microsoft.NETCore.Platforms\"],\"net461\":[\"Microsoft.NETCore.Platforms\"],\"net462\":[\"Microsoft.NETCore.Platforms\"],\"net47\":[\"Microsoft.NETCore.Platforms\"],\"net471\":[\"Microsoft.NETCore.Platforms\"],\"net472\":[\"Microsoft.NETCore.Platforms\"],\"net48\":[\"Microsoft.NETCore.Platforms\"],\"net5.0\":[\"Microsoft.NETCore.Platforms\"],\"net6.0\":[\"Microsoft.NETCore.Platforms\"],\"net7.0\":[\"Microsoft.NETCore.Platforms\"],\"net8.0\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp1.0\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp1.1\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp2.1\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp2.2\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp3.0\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp3.1\":[\"Microsoft.NETCore.Platforms\"],\"netstandard\":[],\"netstandard1.0\":[\"Microsoft.NETCore.Platforms\"],\"netstandard1.1\":[\"Microsoft.NETCore.Platforms\"],\"netstandard1.2\":[\"Microsoft.NETCore.Platforms\"],\"netstandard1.3\":[\"Microsoft.NETCore.Platforms\"],\"netstandard1.4\":[\"Microsoft.NETCore.Platforms\"],\"netstandard1.5\":[\"Microsoft.NETCore.Platforms\"],\"netstandard1.6\":[\"Microsoft.NETCore.Platforms\"],\"netstandard2.0\":[\"Microsoft.NETCore.Platforms\"],\"netstandard2.1\":[\"Microsoft.NETCore.Platforms\"]},\"framework_list\":[],\"id\":\"NETStandard.Library\",\"sha512\":\"sha512-548M6mnBSJWxsIlkQHfbzoYxpiYFXZZSL00p4GHYv8PkiqFBnnT68mW5mGEsA/ch9fDO9GkPgkFQpWiXZN7mAQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"2.0.3\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[\"Microsoft.Win32.Primitives|4.0.3.0\",\"System.AppContext|4.1.2.0\",\"System.Buffers|4.0.3.0\",\"System.Collections.Concurrent|4.0.11.0\",\"System.Collections.NonGeneric|4.0.3.0\",\"System.Collections.Specialized|4.0.3.0\",\"System.Collections|4.0.11.0\",\"System.ComponentModel.Composition|4.0.0.0\",\"System.ComponentModel.EventBasedAsync|4.0.11.0\",\"System.ComponentModel.Primitives|4.1.2.0\",\"System.ComponentModel.TypeConverter|4.1.2.0\",\"System.ComponentModel|4.0.1.0\",\"System.Console|4.0.2.0\",\"System.Core|4.0.0.0\",\"System.Data.Common|4.1.2.0\",\"System.Data|4.0.0.0\",\"System.Diagnostics.Contracts|4.0.1.0\",\"System.Diagnostics.Debug|4.0.11.0\",\"System.Diagnostics.FileVersionInfo|4.0.2.0\",\"System.Diagnostics.Process|4.1.2.0\",\"System.Diagnostics.StackTrace|4.0.4.0\",\"System.Diagnostics.TextWriterTraceListener|4.0.2.0\",\"System.Diagnostics.Tools|4.0.1.0\",\"System.Diagnostics.TraceSource|4.0.2.0\",\"System.Diagnostics.Tracing|4.1.2.0\",\"System.Drawing.Primitives|4.0.2.0\",\"System.Drawing|4.0.0.0\",\"System.Dynamic.Runtime|4.0.11.0\",\"System.Globalization.Calendars|4.0.3.0\",\"System.Globalization.Extensions|4.0.3.0\",\"System.Globalization|4.0.11.0\",\"System.IO.Compression.FileSystem|4.0.0.0\",\"System.IO.Compression.ZipFile|4.0.3.0\",\"System.IO.Compression|4.1.3.0\",\"System.IO.FileSystem.DriveInfo|4.0.2.0\",\"System.IO.FileSystem.Primitives|4.0.3.0\",\"System.IO.FileSystem.Watcher|4.0.2.0\",\"System.IO.FileSystem|4.0.3.0\",\"System.IO.IsolatedStorage|4.0.2.0\",\"System.IO.MemoryMappedFiles|4.0.2.0\",\"System.IO.Pipes|4.0.2.0\",\"System.IO.UnmanagedMemoryStream|4.0.3.0\",\"System.IO|4.1.2.0\",\"System.Linq.Expressions|4.1.2.0\",\"System.Linq.Parallel|4.0.1.0\",\"System.Linq.Queryable|4.0.1.0\",\"System.Linq|4.1.2.0\",\"System.Memory|4.0.2.0\",\"System.Net.Http|4.1.2.0\",\"System.Net.NameResolution|4.0.2.0\",\"System.Net.NetworkInformation|4.1.2.0\",\"System.Net.Ping|4.0.2.0\",\"System.Net.Primitives|4.0.11.0\",\"System.Net.Requests|4.0.11.0\",\"System.Net.Security|4.0.2.0\",\"System.Net.Sockets|4.1.2.0\",\"System.Net.WebHeaderCollection|4.0.1.0\",\"System.Net.WebSockets.Client|4.0.2.0\",\"System.Net.WebSockets|4.0.2.0\",\"System.Net|4.0.0.0\",\"System.Numerics.Vectors|4.1.5.0\",\"System.Numerics|4.0.0.0\",\"System.ObjectModel|4.0.11.0\",\"System.Reflection.DispatchProxy|4.0.5.0\",\"System.Reflection.Emit.ILGeneration|4.0.1.0\",\"System.Reflection.Emit.Lightweight|4.0.1.0\",\"System.Reflection.Emit|4.0.1.0\",\"System.Reflection.Extensions|4.0.1.0\",\"System.Reflection.Primitives|4.0.1.0\",\"System.Reflection|4.1.2.0\",\"System.Resources.Reader|4.0.2.0\",\"System.Resources.ResourceManager|4.0.1.0\",\"System.Resources.Writer|4.0.2.0\",\"System.Runtime.CompilerServices.VisualC|4.0.2.0\",\"System.Runtime.Extensions|4.1.2.0\",\"System.Runtime.Handles|4.0.1.0\",\"System.Runtime.InteropServices.RuntimeInformation|4.0.2.0\",\"System.Runtime.InteropServices|4.1.2.0\",\"System.Runtime.Numerics|4.0.1.0\",\"System.Runtime.Serialization.Formatters|4.0.2.0\",\"System.Runtime.Serialization.Json|4.0.1.0\",\"System.Runtime.Serialization.Primitives|4.1.3.0\",\"System.Runtime.Serialization.Xml|4.1.3.0\",\"System.Runtime.Serialization|4.0.0.0\",\"System.Runtime|4.1.2.0\",\"System.Security.Claims|4.0.3.0\",\"System.Security.Cryptography.Algorithms|4.2.2.0\",\"System.Security.Cryptography.Csp|4.0.2.0\",\"System.Security.Cryptography.Encoding|4.0.2.0\",\"System.Security.Cryptography.Primitives|4.0.2.0\",\"System.Security.Cryptography.X509Certificates|4.1.2.0\",\"System.Security.Principal|4.0.1.0\",\"System.Security.SecureString|4.0.2.0\",\"System.ServiceModel.Web|4.0.0.0\",\"System.Text.Encoding.Extensions|4.0.11.0\",\"System.Text.Encoding|4.0.11.0\",\"System.Text.RegularExpressions|4.1.1.0\",\"System.Threading.Overlapped|4.0.3.0\",\"System.Threading.Tasks.Extensions|4.2.1.0\",\"System.Threading.Tasks.Parallel|4.0.1.0\",\"System.Threading.Tasks|4.0.11.0\",\"System.Threading.Thread|4.0.2.0\",\"System.Threading.ThreadPool|4.0.12.0\",\"System.Threading.Timer|4.0.1.0\",\"System.Threading|4.0.11.0\",\"System.Transactions|4.0.0.0\",\"System.ValueTuple|4.0.2.0\",\"System.Web|4.0.0.0\",\"System.Windows|4.0.0.0\",\"System.Xml.Linq|4.0.0.0\",\"System.Xml.ReaderWriter|4.1.1.0\",\"System.Xml.Serialization|4.0.0.0\",\"System.Xml.XDocument|4.0.11.0\",\"System.Xml.XPath.XDocument|4.0.3.0\",\"System.Xml.XPath|4.0.3.0\",\"System.Xml.XmlDocument|4.0.3.0\",\"System.Xml.XmlSerializer|4.0.11.0\",\"System.Xml|4.0.0.0\",\"System|4.0.0.0\",\"mscorlib|4.0.0.0\",\"netstandard|2.1.0.0\"],\"id\":\"NETStandard.Library.Ref\",\"sha512\":\"sha512-Jr0OqnqkaJJGEVq3w9oNQrIEteD/4QBNg3YOh1cvRjydzwop07+5aWjO/SfEYu6CwBn+dSBKXj8niEvTNy2brA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[\"Microsoft.Win32.Primitives|4.3.0\",\"System.AppContext|4.3.0\",\"System.Collections|4.3.0\",\"System.Collections.Concurrent|4.3.0\",\"System.Collections.Immutable|1.4.0\",\"System.Collections.NonGeneric|4.3.0\",\"System.Collections.Specialized|4.3.0\",\"System.ComponentModel|4.3.0\",\"System.ComponentModel.EventBasedAsync|4.3.0\",\"System.ComponentModel.Primitives|4.3.0\",\"System.ComponentModel.TypeConverter|4.3.0\",\"System.Console|4.3.0\",\"System.Data.Common|4.3.0\",\"System.Diagnostics.Contracts|4.3.0\",\"System.Diagnostics.Debug|4.3.0\",\"System.Diagnostics.FileVersionInfo|4.3.0\",\"System.Diagnostics.Process|4.3.0\",\"System.Diagnostics.StackTrace|4.3.0\",\"System.Diagnostics.TextWriterTraceListener|4.3.0\",\"System.Diagnostics.Tools|4.3.0\",\"System.Diagnostics.TraceSource|4.3.0\",\"System.Diagnostics.Tracing|4.3.0\",\"System.Dynamic.Runtime|4.3.0\",\"System.Globalization|4.3.0\",\"System.Globalization.Calendars|4.3.0\",\"System.Globalization.Extensions|4.3.0\",\"System.IO|4.3.0\",\"System.IO.Compression|4.3.0\",\"System.IO.Compression.ZipFile|4.3.0\",\"System.IO.FileSystem|4.3.0\",\"System.IO.FileSystem.DriveInfo|4.3.0\",\"System.IO.FileSystem.Primitives|4.3.0\",\"System.IO.FileSystem.Watcher|4.3.0\",\"System.IO.IsolatedStorage|4.3.0\",\"System.IO.MemoryMappedFiles|4.3.0\",\"System.IO.Pipes|4.3.0\",\"System.IO.UnmanagedMemoryStream|4.3.0\",\"System.Linq|4.3.0\",\"System.Linq.Expressions|4.3.0\",\"System.Linq.Queryable|4.3.0\",\"System.Net.Http|4.3.0\",\"System.Net.NameResolution|4.3.0\",\"System.Net.Primitives|4.3.0\",\"System.Net.Requests|4.3.0\",\"System.Net.Security|4.3.0\",\"System.Net.Sockets|4.3.0\",\"System.Net.WebHeaderCollection|4.3.0\",\"System.ObjectModel|4.3.0\",\"System.Private.DataContractSerialization|4.3.0\",\"System.Reflection|4.3.0\",\"System.Reflection.Emit|4.3.0\",\"System.Reflection.Emit.ILGeneration|4.3.0\",\"System.Reflection.Emit.Lightweight|4.3.0\",\"System.Reflection.Extensions|4.3.0\",\"System.Reflection.Primitives|4.3.0\",\"System.Reflection.TypeExtensions|4.3.0\",\"System.Resources.ResourceManager|4.3.0\",\"System.Runtime|4.3.0\",\"System.Runtime.Extensions|4.3.0\",\"System.Runtime.Handles|4.3.0\",\"System.Runtime.InteropServices|4.3.0\",\"System.Runtime.InteropServices.RuntimeInformation|4.3.0\",\"System.Runtime.Loader|4.3.0\",\"System.Runtime.Numerics|4.3.0\",\"System.Runtime.Serialization.Formatters|4.3.0\",\"System.Runtime.Serialization.Json|4.3.0\",\"System.Runtime.Serialization.Primitives|4.3.0\",\"System.Security.AccessControl|4.4.0\",\"System.Security.Claims|4.3.0\",\"System.Security.Cryptography.Algorithms|4.3.0\",\"System.Security.Cryptography.Csp|4.3.0\",\"System.Security.Cryptography.Encoding|4.3.0\",\"System.Security.Cryptography.Primitives|4.3.0\",\"System.Security.Cryptography.X509Certificates|4.3.0\",\"System.Security.Cryptography.Xml|4.4.0\",\"System.Security.Principal|4.3.0\",\"System.Security.Principal.Windows|4.4.0\",\"System.Text.Encoding|4.3.0\",\"System.Text.Encoding.Extensions|4.3.0\",\"System.Text.RegularExpressions|4.3.0\",\"System.Threading|4.3.0\",\"System.Threading.Overlapped|4.3.0\",\"System.Threading.Tasks|4.3.0\",\"System.Threading.Tasks.Extensions|4.3.0\",\"System.Threading.Tasks.Parallel|4.3.0\",\"System.Threading.Thread|4.3.0\",\"System.Threading.ThreadPool|4.3.0\",\"System.Threading.Timer|4.3.0\",\"System.ValueTuple|4.3.0\",\"System.Xml.ReaderWriter|4.3.0\",\"System.Xml.XDocument|4.3.0\",\"System.Xml.XmlDocument|4.3.0\",\"System.Xml.XmlSerializer|4.3.0\",\"System.Xml.XPath|4.3.0\",\"System.Xml.XPath.XDocument|4.3.0\"],\"version\":\"2.1.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[\"NETStandard.Library\"],\"netcoreapp1.1\":[\"NETStandard.Library\"],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[\"NETStandard.Library\"],\"netstandard1.1\":[\"NETStandard.Library\"],\"netstandard1.2\":[\"NETStandard.Library\"],\"netstandard1.3\":[\"NETStandard.Library\"],\"netstandard1.4\":[\"NETStandard.Library\"],\"netstandard1.5\":[\"NETStandard.Library\"],\"netstandard1.6\":[\"NETStandard.Library\"],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Newtonsoft.Json\",\"sha512\":\"sha512-g3MbZi6vBTeaI/hEbvR7vBETSd1DWLe9i1E4P+nPY34v5i94zqUqDXvdWC3G+7tYN9SnsdU9zzegrnRz4h7nsQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"13.0.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"net462\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"net47\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"net471\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"net472\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"net48\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"net5.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"net6.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"net7.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"net8.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"netcoreapp2.1\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"netcoreapp2.2\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"netcoreapp3.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"netcoreapp3.1\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"],\"netstandard2.1\":[\"NuGet.Credentials\",\"NuGet.ProjectModel\"]},\"framework_list\":[],\"id\":\"NuGet.Commands\",\"sha512\":\"sha512-Q7ANXnmLUPC4pWgCZjBy2R7vRDABiaJz5NsBtoErE0dLylx/zQWRMyoa+m4Y478SKvUpt7S1V7LhAOlMRCTPpg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[\"NuGet.Frameworks\"],\"net451\":[\"NuGet.Frameworks\"],\"net452\":[\"NuGet.Frameworks\"],\"net46\":[\"NuGet.Frameworks\"],\"net461\":[\"NuGet.Frameworks\"],\"net462\":[\"NuGet.Frameworks\"],\"net47\":[\"NuGet.Frameworks\"],\"net471\":[\"NuGet.Frameworks\"],\"net472\":[\"NuGet.Frameworks\"],\"net48\":[\"NuGet.Frameworks\"],\"net5.0\":[\"NuGet.Frameworks\"],\"net6.0\":[\"NuGet.Frameworks\"],\"net7.0\":[\"NuGet.Frameworks\"],\"net8.0\":[\"NuGet.Frameworks\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Frameworks\"],\"netcoreapp2.1\":[\"NuGet.Frameworks\"],\"netcoreapp2.2\":[\"NuGet.Frameworks\"],\"netcoreapp3.0\":[\"NuGet.Frameworks\"],\"netcoreapp3.1\":[\"NuGet.Frameworks\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Frameworks\"],\"netstandard2.1\":[\"NuGet.Frameworks\"]},\"framework_list\":[],\"id\":\"NuGet.Common\",\"sha512\":\"sha512-8M9VtXAB1M15KmvL0F9QsItI96PH3WmYD0z3oxYm5H9G5AIhK8Ivi4kGzqtBJDTsZ/NkP91U1MnoCAeg4E4+zA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[\"NuGet.Common\"],\"net451\":[\"NuGet.Common\"],\"net452\":[\"NuGet.Common\"],\"net46\":[\"NuGet.Common\"],\"net461\":[\"NuGet.Common\"],\"net462\":[\"NuGet.Common\"],\"net47\":[\"NuGet.Common\"],\"net471\":[\"NuGet.Common\"],\"net472\":[\"NuGet.Common\"],\"net48\":[\"NuGet.Common\"],\"net5.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"net6.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"net7.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"net8.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp2.1\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp2.2\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp3.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netcoreapp3.1\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"],\"netstandard2.1\":[\"NuGet.Common\",\"System.Security.Cryptography.ProtectedData\"]},\"framework_list\":[],\"id\":\"NuGet.Configuration\",\"sha512\":\"sha512-ZJc2HY/D+UEk2U0jxamyBhUbKl2bgluViM/tnP4ObIIfJpOj8dHEJ6xzggulIGDlhe+ItK6yc+sqtCb6qV5+gw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Protocol\"],\"net462\":[\"NuGet.Protocol\"],\"net47\":[\"NuGet.Protocol\"],\"net471\":[\"NuGet.Protocol\"],\"net472\":[\"NuGet.Protocol\"],\"net48\":[\"NuGet.Protocol\"],\"net5.0\":[\"NuGet.Protocol\"],\"net6.0\":[\"NuGet.Protocol\"],\"net7.0\":[\"NuGet.Protocol\"],\"net8.0\":[\"NuGet.Protocol\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Protocol\"],\"netcoreapp2.1\":[\"NuGet.Protocol\"],\"netcoreapp2.2\":[\"NuGet.Protocol\"],\"netcoreapp3.0\":[\"NuGet.Protocol\"],\"netcoreapp3.1\":[\"NuGet.Protocol\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Protocol\"],\"netstandard2.1\":[\"NuGet.Protocol\"]},\"framework_list\":[],\"id\":\"NuGet.Credentials\",\"sha512\":\"sha512-r/fzn5yJaCXyChbhxbGZ5d/4xV4n3NIjVdE3odLfQy0znmcYRCDIfjYGu5l7vO9Nx27F+q7YA+9QmG9sucxX9A==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net462\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net47\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net471\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net472\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net48\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net5.0\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net6.0\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net7.0\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"net8.0\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netcoreapp2.1\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netcoreapp2.2\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netcoreapp3.0\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netcoreapp3.1\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"],\"netstandard2.1\":[\"NuGet.LibraryModel\",\"NuGet.Protocol\"]},\"framework_list\":[],\"id\":\"NuGet.DependencyResolver.Core\",\"sha512\":\"sha512-+9mCFiBhnm5C2Cb3dtHaHyv/WarSr5HwRi2NaoVJgudpHoK3B9uy8wB7PNnUos0kOghZmVslemeLsmw7icQqTw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"NuGet.Frameworks\",\"sha512\":\"sha512-l8KtHN2bzA391seLZ9Q2AWK0mbCHpfbwL1nmOSMDxBpWLxqh+nxMWaKL437bROpHltU+oP5LX/hc4Fxm89T9Tg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net462\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net47\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net471\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net472\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net48\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net5.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net6.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net7.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"net8.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netcoreapp2.1\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netcoreapp2.2\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netcoreapp3.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netcoreapp3.1\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Common\",\"NuGet.Versioning\"],\"netstandard2.1\":[\"NuGet.Common\",\"NuGet.Versioning\"]},\"framework_list\":[],\"id\":\"NuGet.LibraryModel\",\"sha512\":\"sha512-xb8XLKJEMymZMAZJeXdSUaDNFRQMJ4MXkOPUaqafcgSKGz8M8BZgfLsBz9QCQVEyHIVYGbI4yroWZYed/c8xSg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net462\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net47\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net471\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net472\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\"],\"net48\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\"],\"net5.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net6.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net7.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"net8.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netcoreapp2.1\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netcoreapp2.2\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netcoreapp3.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netcoreapp3.1\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"],\"netstandard2.1\":[\"NuGet.Commands\",\"NuGet.Resolver\",\"Microsoft.Web.Xdt\",\"System.ComponentModel.Composition\"]},\"framework_list\":[],\"id\":\"NuGet.PackageManagement\",\"sha512\":\"sha512-Kr0CZuStXNsJRL86ecuWGhIHUhYy31rYZJ9WZ0tiFUaRwiPb7HpSQVsV/v3tqrKE7FWUZBpasX1bugXNqXcPjA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"net462\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"net47\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"net471\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"net472\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\"],\"net48\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\"],\"net5.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"net6.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"net7.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"net8.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"netcoreapp2.1\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"netcoreapp2.2\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"netcoreapp3.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"netcoreapp3.1\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"],\"netstandard2.1\":[\"NuGet.Configuration\",\"NuGet.Versioning\",\"Newtonsoft.Json\",\"System.Security.Cryptography.Cng\",\"System.Security.Cryptography.Pkcs\"]},\"framework_list\":[],\"id\":\"Nuget.Packaging\",\"sha512\":\"sha512-2HMq5gNgLMOHmqGb84pyEC7ctkCYBVXkhJfcYmHlkpo4FpDA6GQBoT//1h0Q4nGoybtgoBxiIbJu8VRn/9CZrQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"Nuget.Packaging.Core\",\"sha512\":\"sha512-/WXGAbLb4T0pwEfEeY0j8zOVpS36OHNUANL95txANysbLoG7tUr9e+5je+Nfh3iIqzMaHIZXT6JKFvHOBwAotw==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.DependencyResolver.Core\"],\"net462\":[\"NuGet.DependencyResolver.Core\"],\"net47\":[\"NuGet.DependencyResolver.Core\"],\"net471\":[\"NuGet.DependencyResolver.Core\"],\"net472\":[\"NuGet.DependencyResolver.Core\"],\"net48\":[\"NuGet.DependencyResolver.Core\"],\"net5.0\":[\"NuGet.DependencyResolver.Core\"],\"net6.0\":[\"NuGet.DependencyResolver.Core\"],\"net7.0\":[\"NuGet.DependencyResolver.Core\"],\"net8.0\":[\"NuGet.DependencyResolver.Core\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.DependencyResolver.Core\"],\"netcoreapp2.1\":[\"NuGet.DependencyResolver.Core\"],\"netcoreapp2.2\":[\"NuGet.DependencyResolver.Core\"],\"netcoreapp3.0\":[\"NuGet.DependencyResolver.Core\"],\"netcoreapp3.1\":[\"NuGet.DependencyResolver.Core\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.DependencyResolver.Core\"],\"netstandard2.1\":[\"NuGet.DependencyResolver.Core\"]},\"framework_list\":[],\"id\":\"NuGet.ProjectModel\",\"sha512\":\"sha512-gsZS2Kuat3ZjjPcBQ3Mc8QlRv6mP1OzNzkF4Dzybu3LgtG+kwvgQh4UMLbiIrko6WKbwVTbr8nQYpL+wsVZ4hA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"NuGet.Protocol\",\"sha512\":\"sha512-lY85Pgf7kr0JwTufdJmfDgBwN9BRQc96F4xxKrUGSALhuZRRC7y6f2RN1JQ0UTPIXlQx7HTG/h0UZEknQj3/UQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[\"NuGet.Protocol\"],\"net462\":[\"NuGet.Protocol\"],\"net47\":[\"NuGet.Protocol\"],\"net471\":[\"NuGet.Protocol\"],\"net472\":[\"NuGet.Protocol\"],\"net48\":[\"NuGet.Protocol\"],\"net5.0\":[\"NuGet.Protocol\"],\"net6.0\":[\"NuGet.Protocol\"],\"net7.0\":[\"NuGet.Protocol\"],\"net8.0\":[\"NuGet.Protocol\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"NuGet.Protocol\"],\"netcoreapp2.1\":[\"NuGet.Protocol\"],\"netcoreapp2.2\":[\"NuGet.Protocol\"],\"netcoreapp3.0\":[\"NuGet.Protocol\"],\"netcoreapp3.1\":[\"NuGet.Protocol\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"NuGet.Protocol\"],\"netstandard2.1\":[\"NuGet.Protocol\"]},\"framework_list\":[],\"id\":\"NuGet.Resolver\",\"sha512\":\"sha512-a2zWl9RkKDkcVUqfRJjz3O4uoPIWf3PGaFf6AntXtTKjvvsB6SZz8jjPSGdLgTTRIWzsFlybKp6yU+GaXeIQkg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"NuGet.Versioning\",\"sha512\":\"sha512-NW11tfXijCWeI8d71HKpNPKPzJqr30PtUyJHzCpKFMFTGZhsHh2YxgjKBuhpC5R59SMZUzqrFF5CgJ8uGaupqg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.10.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"NETStandard.Library\"],\"net6.0\":[\"NETStandard.Library\"],\"net7.0\":[\"NETStandard.Library\"],\"net8.0\":[\"NETStandard.Library\"],\"netcoreapp1.0\":[\"NETStandard.Library\"],\"netcoreapp1.1\":[\"NETStandard.Library\"],\"netcoreapp2.0\":[\"NETStandard.Library\"],\"netcoreapp2.1\":[\"NETStandard.Library\"],\"netcoreapp2.2\":[\"NETStandard.Library\"],\"netcoreapp3.0\":[\"NETStandard.Library\"],\"netcoreapp3.1\":[\"NETStandard.Library\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[\"NETStandard.Library\"],\"netstandard1.5\":[\"NETStandard.Library\"],\"netstandard1.6\":[\"NETStandard.Library\"],\"netstandard2.0\":[\"NETStandard.Library\"],\"netstandard2.1\":[\"NETStandard.Library\"]},\"framework_list\":[],\"id\":\"NUnit\",\"sha512\":\"sha512-HAhwFxr+Z+PJf8hXzc747NecvsDwEZ+3X8SA5+GIRM43GAy1Ap+TQPMHsWCnisfes5vPZ1/a2md/91u+shoTsQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"3.12.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[\"NUnit\"],\"net40\":[\"NUnit\"],\"net403\":[\"NUnit\"],\"net45\":[\"NUnit\"],\"net451\":[\"NUnit\"],\"net452\":[\"NUnit\"],\"net46\":[\"NUnit\"],\"net461\":[\"NUnit\"],\"net462\":[\"NUnit\"],\"net47\":[\"NUnit\"],\"net471\":[\"NUnit\"],\"net472\":[\"NUnit\"],\"net48\":[\"NUnit\"],\"net5.0\":[\"NUnit\",\"NETStandard.Library\"],\"net6.0\":[\"NUnit\",\"NETStandard.Library\"],\"net7.0\":[\"NUnit\",\"NETStandard.Library\"],\"net8.0\":[\"NUnit\",\"NETStandard.Library\"],\"netcoreapp1.0\":[\"NUnit\",\"NETStandard.Library\"],\"netcoreapp1.1\":[\"NUnit\",\"NETStandard.Library\"],\"netcoreapp2.0\":[\"NUnit\",\"NETStandard.Library\"],\"netcoreapp2.1\":[\"NUnit\",\"NETStandard.Library\"],\"netcoreapp2.2\":[\"NUnit\",\"NETStandard.Library\"],\"netcoreapp3.0\":[\"NUnit\",\"NETStandard.Library\"],\"netcoreapp3.1\":[\"NUnit\",\"NETStandard.Library\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[\"NUnit\",\"NETStandard.Library\"],\"netstandard1.5\":[\"NUnit\",\"NETStandard.Library\"],\"netstandard1.6\":[\"NUnit\",\"NETStandard.Library\"],\"netstandard2.0\":[\"NUnit\",\"NETStandard.Library\"],\"netstandard2.1\":[\"NUnit\",\"NETStandard.Library\"]},\"framework_list\":[],\"id\":\"NUnitLite\",\"sha512\":\"sha512-M9VVS4x3KURXFS4HTl2b7uJOX7vOi2wzpHACmNX6ANlBmb0/hIehJLciiVvddD3ubIIL81EF4Qk54kpsUOtVFQ==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"3.12.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[\"NETStandard.Library\"],\"netcoreapp1.1\":[\"NETStandard.Library\"],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[\"NETStandard.Library\"],\"netstandard1.2\":[\"NETStandard.Library\"],\"netstandard1.3\":[\"NETStandard.Library\"],\"netstandard1.4\":[\"NETStandard.Library\"],\"netstandard1.5\":[\"NETStandard.Library\"],\"netstandard1.6\":[\"NETStandard.Library\"],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.ComponentModel.Annotations\",\"sha512\":\"sha512-WJqsTGaXAc55EPGjJylPFXiNPs/x1t9dklVlHlIBxUEcIxIob6sRGm9Un7TehkyEFM+vKjZd7rbwaMH/znw1PA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.ComponentModel.Composition\",\"sha512\":\"sha512-YWQ3ENu0D2st9ZV+Yj4u3IFcas0Pw7S4c7ymDUooPLb1psNJ53YniX2orSiY2OlRWnssaUsTytnVJa/KfCn5aA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Formats.Asn1\",\"sha512\":\"sha512-62YP6zLnvmFtFI3rjybbrnSeK6hHQCaFfJJfoNhQqrETJBPehSucQxIyQs5W+GGBW/rpSXD/0NqNW7mttIWXhA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"System.Formats.Asn1\"],\"net6.0\":[\"System.Formats.Asn1\"],\"net7.0\":[\"System.Formats.Asn1\"],\"net8.0\":[\"System.Formats.Asn1\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"Microsoft.NETCore.Platforms\"],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[\"System.Formats.Asn1\"],\"netcoreapp3.1\":[\"System.Formats.Asn1\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Security.Cryptography.Cng\",\"sha512\":\"sha512-trvkAklUhzM+/z9bPnGmDLzmbvD0l1IlC6gpFRpzjGLylTgtTPqm8Uv7tnDBTuBQObjEZBxNS0bChIi6zQCV9w==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"5.0.0\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"net6.0\":[\"System.Formats.Asn1\"],\"net7.0\":[\"System.Formats.Asn1\"],\"net8.0\":[\"System.Formats.Asn1\"],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"netcoreapp2.1\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"netcoreapp2.2\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"netcoreapp3.0\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"netcoreapp3.1\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"],\"netstandard2.1\":[\"System.Formats.Asn1\",\"System.Security.Cryptography.Cng\"]},\"framework_list\":[],\"id\":\"System.Security.Cryptography.Pkcs\",\"sha512\":\"sha512-ubxxZt0n9t8Xe/NtN53XMf6ZSfRKsk/T+mheDuoZbYrBJRLVyQ4pecXoROihl/DyC9uVOt6QrejwLAx1Raj1wg==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.1\"}",
+                "{\"dependencies\":{\"net11\":[],\"net20\":[],\"net30\":[],\"net35\":[],\"net40\":[],\"net403\":[],\"net45\":[],\"net451\":[],\"net452\":[],\"net46\":[],\"net461\":[],\"net462\":[],\"net47\":[],\"net471\":[],\"net472\":[],\"net48\":[],\"net5.0\":[],\"net6.0\":[],\"net7.0\":[],\"net8.0\":[],\"netcoreapp1.0\":[],\"netcoreapp1.1\":[],\"netcoreapp2.0\":[],\"netcoreapp2.1\":[],\"netcoreapp2.2\":[],\"netcoreapp3.0\":[],\"netcoreapp3.1\":[],\"netstandard\":[],\"netstandard1.0\":[],\"netstandard1.1\":[],\"netstandard1.2\":[],\"netstandard1.3\":[],\"netstandard1.4\":[],\"netstandard1.5\":[],\"netstandard1.6\":[],\"netstandard2.0\":[],\"netstandard2.1\":[]},\"framework_list\":[],\"id\":\"System.Security.Cryptography.ProtectedData\",\"sha512\":\"sha512-SJtdqwq/rfuLwtBDfeg6FEeRgHGUlEDnZttwHIHDUY3mo4o+D2mXBrBtWRq1OTx7wLLqqBwVv/FWM5JI5sNXMA==\",\"sources\":[\"https://api.nuget.org/v3/index.json\"],\"targeting_pack_overrides\":[],\"version\":\"6.0.0\"}"
+              ],
+              "targeting_pack_overrides": {
+                "mcmaster.extensions.commandlineutils": [],
+                "microsoft.netcore.app.ref": [
+                  "Microsoft.CSharp|4.4.0",
+                  "Microsoft.Win32.Primitives|4.3.0",
+                  "Microsoft.Win32.Registry|4.4.0",
+                  "runtime.debian.8-x64.runtime.native.System|4.3.0",
+                  "runtime.debian.8-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.debian.8-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.debian.8-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.debian.8-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "runtime.fedora.23-x64.runtime.native.System|4.3.0",
+                  "runtime.fedora.23-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.fedora.23-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.fedora.23-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "runtime.fedora.24-x64.runtime.native.System|4.3.0",
+                  "runtime.fedora.24-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.fedora.24-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.fedora.24-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "runtime.opensuse.13.2-x64.runtime.native.System|4.3.0",
+                  "runtime.opensuse.13.2-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.opensuse.13.2-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.opensuse.13.2-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "runtime.opensuse.42.1-x64.runtime.native.System|4.3.0",
+                  "runtime.opensuse.42.1-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.opensuse.42.1-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.opensuse.42.1-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "runtime.osx.10.10-x64.runtime.native.System|4.3.0",
+                  "runtime.osx.10.10-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.osx.10.10-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.osx.10.10-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple|4.3.0",
+                  "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "runtime.rhel.7-x64.runtime.native.System|4.3.0",
+                  "runtime.rhel.7-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.rhel.7-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.rhel.7-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "runtime.ubuntu.14.04-x64.runtime.native.System|4.3.0",
+                  "runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.ubuntu.14.04-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "runtime.ubuntu.16.04-x64.runtime.native.System|4.3.0",
+                  "runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.ubuntu.16.04-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "runtime.ubuntu.16.10-x64.runtime.native.System|4.3.0",
+                  "runtime.ubuntu.16.10-x64.runtime.native.System.IO.Compression|4.3.0",
+                  "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Http|4.3.0",
+                  "runtime.ubuntu.16.10-x64.runtime.native.System.Net.Security|4.3.0",
+                  "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography|4.3.0",
+                  "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl|4.3.0",
+                  "System.AppContext|4.3.0",
+                  "System.Buffers|4.4.0",
+                  "System.Collections|4.3.0",
+                  "System.Collections.Concurrent|4.3.0",
+                  "System.Collections.Immutable|1.4.0",
+                  "System.Collections.NonGeneric|4.3.0",
+                  "System.Collections.Specialized|4.3.0",
+                  "System.ComponentModel|4.3.0",
+                  "System.ComponentModel.EventBasedAsync|4.3.0",
+                  "System.ComponentModel.Primitives|4.3.0",
+                  "System.ComponentModel.TypeConverter|4.3.0",
+                  "System.Console|4.3.0",
+                  "System.Data.Common|4.3.0",
+                  "System.Diagnostics.Contracts|4.3.0",
+                  "System.Diagnostics.Debug|4.3.0",
+                  "System.Diagnostics.DiagnosticSource|4.4.0",
+                  "System.Diagnostics.FileVersionInfo|4.3.0",
+                  "System.Diagnostics.Process|4.3.0",
+                  "System.Diagnostics.StackTrace|4.3.0",
+                  "System.Diagnostics.TextWriterTraceListener|4.3.0",
+                  "System.Diagnostics.Tools|4.3.0",
+                  "System.Diagnostics.TraceSource|4.3.0",
+                  "System.Diagnostics.Tracing|4.3.0",
+                  "System.Dynamic.Runtime|4.3.0",
+                  "System.Globalization|4.3.0",
+                  "System.Globalization.Calendars|4.3.0",
+                  "System.Globalization.Extensions|4.3.0",
+                  "System.IO|4.3.0",
+                  "System.IO.Compression|4.3.0",
+                  "System.IO.Compression.ZipFile|4.3.0",
+                  "System.IO.FileSystem|4.3.0",
+                  "System.IO.FileSystem.AccessControl|4.4.0",
+                  "System.IO.FileSystem.DriveInfo|4.3.0",
+                  "System.IO.FileSystem.Primitives|4.3.0",
+                  "System.IO.FileSystem.Watcher|4.3.0",
+                  "System.IO.IsolatedStorage|4.3.0",
+                  "System.IO.MemoryMappedFiles|4.3.0",
+                  "System.IO.Pipes|4.3.0",
+                  "System.IO.UnmanagedMemoryStream|4.3.0",
+                  "System.Linq|4.3.0",
+                  "System.Linq.Expressions|4.3.0",
+                  "System.Linq.Queryable|4.3.0",
+                  "System.Net.Http|4.3.0",
+                  "System.Net.NameResolution|4.3.0",
+                  "System.Net.Primitives|4.3.0",
+                  "System.Net.Requests|4.3.0",
+                  "System.Net.Security|4.3.0",
+                  "System.Net.Sockets|4.3.0",
+                  "System.Net.WebHeaderCollection|4.3.0",
+                  "System.ObjectModel|4.3.0",
+                  "System.Private.DataContractSerialization|4.3.0",
+                  "System.Reflection|4.3.0",
+                  "System.Reflection.Emit|4.3.0",
+                  "System.Reflection.Emit.ILGeneration|4.3.0",
+                  "System.Reflection.Emit.Lightweight|4.3.0",
+                  "System.Reflection.Extensions|4.3.0",
+                  "System.Reflection.Metadata|1.5.0",
+                  "System.Reflection.Primitives|4.3.0",
+                  "System.Reflection.TypeExtensions|4.3.0",
+                  "System.Resources.ResourceManager|4.3.0",
+                  "System.Runtime|4.3.0",
+                  "System.Runtime.Extensions|4.3.0",
+                  "System.Runtime.Handles|4.3.0",
+                  "System.Runtime.InteropServices|4.3.0",
+                  "System.Runtime.InteropServices.RuntimeInformation|4.3.0",
+                  "System.Runtime.Loader|4.3.0",
+                  "System.Runtime.Numerics|4.3.0",
+                  "System.Runtime.Serialization.Formatters|4.3.0",
+                  "System.Runtime.Serialization.Json|4.3.0",
+                  "System.Runtime.Serialization.Primitives|4.3.0",
+                  "System.Security.AccessControl|4.4.0",
+                  "System.Security.Claims|4.3.0",
+                  "System.Security.Cryptography.Algorithms|4.3.0",
+                  "System.Security.Cryptography.Cng|4.4.0",
+                  "System.Security.Cryptography.Csp|4.3.0",
+                  "System.Security.Cryptography.Encoding|4.3.0",
+                  "System.Security.Cryptography.OpenSsl|4.4.0",
+                  "System.Security.Cryptography.Primitives|4.3.0",
+                  "System.Security.Cryptography.X509Certificates|4.3.0",
+                  "System.Security.Cryptography.Xml|4.4.0",
+                  "System.Security.Principal|4.3.0",
+                  "System.Security.Principal.Windows|4.4.0",
+                  "System.Text.Encoding|4.3.0",
+                  "System.Text.Encoding.Extensions|4.3.0",
+                  "System.Text.RegularExpressions|4.3.0",
+                  "System.Threading|4.3.0",
+                  "System.Threading.Overlapped|4.3.0",
+                  "System.Threading.Tasks|4.3.0",
+                  "System.Threading.Tasks.Extensions|4.3.0",
+                  "System.Threading.Tasks.Parallel|4.3.0",
+                  "System.Threading.Thread|4.3.0",
+                  "System.Threading.ThreadPool|4.3.0",
+                  "System.Threading.Timer|4.3.0",
+                  "System.ValueTuple|4.3.0",
+                  "System.Xml.ReaderWriter|4.3.0",
+                  "System.Xml.XDocument|4.3.0",
+                  "System.Xml.XmlDocument|4.3.0",
+                  "System.Xml.XmlSerializer|4.3.0",
+                  "System.Xml.XPath|4.3.0",
+                  "System.Xml.XPath.XDocument|4.3.0"
+                ],
+                "microsoft.netcore.platforms": [],
+                "microsoft.web.xdt": [],
+                "netstandard.library": [],
+                "netstandard.library.ref": [
+                  "Microsoft.Win32.Primitives|4.3.0",
+                  "System.AppContext|4.3.0",
+                  "System.Collections|4.3.0",
+                  "System.Collections.Concurrent|4.3.0",
+                  "System.Collections.Immutable|1.4.0",
+                  "System.Collections.NonGeneric|4.3.0",
+                  "System.Collections.Specialized|4.3.0",
+                  "System.ComponentModel|4.3.0",
+                  "System.ComponentModel.EventBasedAsync|4.3.0",
+                  "System.ComponentModel.Primitives|4.3.0",
+                  "System.ComponentModel.TypeConverter|4.3.0",
+                  "System.Console|4.3.0",
+                  "System.Data.Common|4.3.0",
+                  "System.Diagnostics.Contracts|4.3.0",
+                  "System.Diagnostics.Debug|4.3.0",
+                  "System.Diagnostics.FileVersionInfo|4.3.0",
+                  "System.Diagnostics.Process|4.3.0",
+                  "System.Diagnostics.StackTrace|4.3.0",
+                  "System.Diagnostics.TextWriterTraceListener|4.3.0",
+                  "System.Diagnostics.Tools|4.3.0",
+                  "System.Diagnostics.TraceSource|4.3.0",
+                  "System.Diagnostics.Tracing|4.3.0",
+                  "System.Dynamic.Runtime|4.3.0",
+                  "System.Globalization|4.3.0",
+                  "System.Globalization.Calendars|4.3.0",
+                  "System.Globalization.Extensions|4.3.0",
+                  "System.IO|4.3.0",
+                  "System.IO.Compression|4.3.0",
+                  "System.IO.Compression.ZipFile|4.3.0",
+                  "System.IO.FileSystem|4.3.0",
+                  "System.IO.FileSystem.DriveInfo|4.3.0",
+                  "System.IO.FileSystem.Primitives|4.3.0",
+                  "System.IO.FileSystem.Watcher|4.3.0",
+                  "System.IO.IsolatedStorage|4.3.0",
+                  "System.IO.MemoryMappedFiles|4.3.0",
+                  "System.IO.Pipes|4.3.0",
+                  "System.IO.UnmanagedMemoryStream|4.3.0",
+                  "System.Linq|4.3.0",
+                  "System.Linq.Expressions|4.3.0",
+                  "System.Linq.Queryable|4.3.0",
+                  "System.Net.Http|4.3.0",
+                  "System.Net.NameResolution|4.3.0",
+                  "System.Net.Primitives|4.3.0",
+                  "System.Net.Requests|4.3.0",
+                  "System.Net.Security|4.3.0",
+                  "System.Net.Sockets|4.3.0",
+                  "System.Net.WebHeaderCollection|4.3.0",
+                  "System.ObjectModel|4.3.0",
+                  "System.Private.DataContractSerialization|4.3.0",
+                  "System.Reflection|4.3.0",
+                  "System.Reflection.Emit|4.3.0",
+                  "System.Reflection.Emit.ILGeneration|4.3.0",
+                  "System.Reflection.Emit.Lightweight|4.3.0",
+                  "System.Reflection.Extensions|4.3.0",
+                  "System.Reflection.Primitives|4.3.0",
+                  "System.Reflection.TypeExtensions|4.3.0",
+                  "System.Resources.ResourceManager|4.3.0",
+                  "System.Runtime|4.3.0",
+                  "System.Runtime.Extensions|4.3.0",
+                  "System.Runtime.Handles|4.3.0",
+                  "System.Runtime.InteropServices|4.3.0",
+                  "System.Runtime.InteropServices.RuntimeInformation|4.3.0",
+                  "System.Runtime.Loader|4.3.0",
+                  "System.Runtime.Numerics|4.3.0",
+                  "System.Runtime.Serialization.Formatters|4.3.0",
+                  "System.Runtime.Serialization.Json|4.3.0",
+                  "System.Runtime.Serialization.Primitives|4.3.0",
+                  "System.Security.AccessControl|4.4.0",
+                  "System.Security.Claims|4.3.0",
+                  "System.Security.Cryptography.Algorithms|4.3.0",
+                  "System.Security.Cryptography.Csp|4.3.0",
+                  "System.Security.Cryptography.Encoding|4.3.0",
+                  "System.Security.Cryptography.Primitives|4.3.0",
+                  "System.Security.Cryptography.X509Certificates|4.3.0",
+                  "System.Security.Cryptography.Xml|4.4.0",
+                  "System.Security.Principal|4.3.0",
+                  "System.Security.Principal.Windows|4.4.0",
+                  "System.Text.Encoding|4.3.0",
+                  "System.Text.Encoding.Extensions|4.3.0",
+                  "System.Text.RegularExpressions|4.3.0",
+                  "System.Threading|4.3.0",
+                  "System.Threading.Overlapped|4.3.0",
+                  "System.Threading.Tasks|4.3.0",
+                  "System.Threading.Tasks.Extensions|4.3.0",
+                  "System.Threading.Tasks.Parallel|4.3.0",
+                  "System.Threading.Thread|4.3.0",
+                  "System.Threading.ThreadPool|4.3.0",
+                  "System.Threading.Timer|4.3.0",
+                  "System.ValueTuple|4.3.0",
+                  "System.Xml.ReaderWriter|4.3.0",
+                  "System.Xml.XDocument|4.3.0",
+                  "System.Xml.XmlDocument|4.3.0",
+                  "System.Xml.XmlSerializer|4.3.0",
+                  "System.Xml.XPath|4.3.0",
+                  "System.Xml.XPath.XDocument|4.3.0"
+                ],
+                "newtonsoft.json": [],
+                "nuget.commands": [],
+                "nuget.common": [],
+                "nuget.configuration": [],
+                "nuget.credentials": [],
+                "nuget.dependencyresolver.core": [],
+                "nuget.frameworks": [],
+                "nuget.librarymodel": [],
+                "nuget.packagemanagement": [],
+                "nuget.packaging": [],
+                "nuget.packaging.core": [],
+                "nuget.projectmodel": [],
+                "nuget.protocol": [],
+                "nuget.resolver": [],
+                "nuget.versioning": [],
+                "nunit": [],
+                "nunitlite": [],
+                "system.componentmodel.annotations": [],
+                "system.componentmodel.composition": [],
+                "system.formats.asn1": [],
+                "system.security.cryptography.cng": [],
+                "system.security.cryptography.pkcs": [],
+                "system.security.cryptography.protecteddata": []
+              },
+              "framework_list": {
+                "mcmaster.extensions.commandlineutils": [],
+                "microsoft.netcore.app.ref": [
+                  "Microsoft.CSharp|6.0.0.0",
+                  "Microsoft.VisualBasic.Core|11.0.0.0",
+                  "Microsoft.VisualBasic|10.0.0.0",
+                  "Microsoft.Win32.Primitives|6.0.0.0",
+                  "Microsoft.Win32.Registry|6.0.0.0",
+                  "System.AppContext|6.0.0.0",
+                  "System.Buffers|6.0.0.0",
+                  "System.Collections.Concurrent|6.0.0.0",
+                  "System.Collections.Immutable|6.0.0.0",
+                  "System.Collections.NonGeneric|6.0.0.0",
+                  "System.Collections.Specialized|6.0.0.0",
+                  "System.Collections|6.0.0.0",
+                  "System.ComponentModel.Annotations|6.0.0.0",
+                  "System.ComponentModel.DataAnnotations|4.0.0.0",
+                  "System.ComponentModel.EventBasedAsync|6.0.0.0",
+                  "System.ComponentModel.Primitives|6.0.0.0",
+                  "System.ComponentModel.TypeConverter|6.0.0.0",
+                  "System.ComponentModel|6.0.0.0",
+                  "System.Configuration|4.0.0.0",
+                  "System.Console|6.0.0.0",
+                  "System.Core|4.0.0.0",
+                  "System.Data.Common|6.0.0.0",
+                  "System.Data.DataSetExtensions|4.0.0.0",
+                  "System.Data|4.0.0.0",
+                  "System.Diagnostics.Contracts|6.0.0.0",
+                  "System.Diagnostics.Debug|6.0.0.0",
+                  "System.Diagnostics.DiagnosticSource|6.0.0.0",
+                  "System.Diagnostics.FileVersionInfo|6.0.0.0",
+                  "System.Diagnostics.Process|6.0.0.0",
+                  "System.Diagnostics.StackTrace|6.0.0.0",
+                  "System.Diagnostics.TextWriterTraceListener|6.0.0.0",
+                  "System.Diagnostics.Tools|6.0.0.0",
+                  "System.Diagnostics.TraceSource|6.0.0.0",
+                  "System.Diagnostics.Tracing|6.0.0.0",
+                  "System.Drawing.Primitives|6.0.0.0",
+                  "System.Drawing|4.0.0.0",
+                  "System.Dynamic.Runtime|6.0.0.0",
+                  "System.Formats.Asn1|6.0.0.0",
+                  "System.Globalization.Calendars|6.0.0.0",
+                  "System.Globalization.Extensions|6.0.0.0",
+                  "System.Globalization|6.0.0.0",
+                  "System.IO.Compression.Brotli|6.0.0.0",
+                  "System.IO.Compression.FileSystem|4.0.0.0",
+                  "System.IO.Compression.ZipFile|6.0.0.0",
+                  "System.IO.Compression|6.0.0.0",
+                  "System.IO.FileSystem.AccessControl|6.0.0.0",
+                  "System.IO.FileSystem.DriveInfo|6.0.0.0",
+                  "System.IO.FileSystem.Primitives|6.0.0.0",
+                  "System.IO.FileSystem.Watcher|6.0.0.0",
+                  "System.IO.FileSystem|6.0.0.0",
+                  "System.IO.IsolatedStorage|6.0.0.0",
+                  "System.IO.MemoryMappedFiles|6.0.0.0",
+                  "System.IO.Pipes.AccessControl|6.0.0.0",
+                  "System.IO.Pipes|6.0.0.0",
+                  "System.IO.UnmanagedMemoryStream|6.0.0.0",
+                  "System.IO|6.0.0.0",
+                  "System.Linq.Expressions|6.0.0.0",
+                  "System.Linq.Parallel|6.0.0.0",
+                  "System.Linq.Queryable|6.0.0.0",
+                  "System.Linq|6.0.0.0",
+                  "System.Memory|6.0.0.0",
+                  "System.Net.Http.Json|6.0.0.0",
+                  "System.Net.Http|6.0.0.0",
+                  "System.Net.HttpListener|6.0.0.0",
+                  "System.Net.Mail|6.0.0.0",
+                  "System.Net.NameResolution|6.0.0.0",
+                  "System.Net.NetworkInformation|6.0.0.0",
+                  "System.Net.Ping|6.0.0.0",
+                  "System.Net.Primitives|6.0.0.0",
+                  "System.Net.Requests|6.0.0.0",
+                  "System.Net.Security|6.0.0.0",
+                  "System.Net.ServicePoint|6.0.0.0",
+                  "System.Net.Sockets|6.0.0.0",
+                  "System.Net.WebClient|6.0.0.0",
+                  "System.Net.WebHeaderCollection|6.0.0.0",
+                  "System.Net.WebProxy|6.0.0.0",
+                  "System.Net.WebSockets.Client|6.0.0.0",
+                  "System.Net.WebSockets|6.0.0.0",
+                  "System.Net|4.0.0.0",
+                  "System.Numerics.Vectors|6.0.0.0",
+                  "System.Numerics|4.0.0.0",
+                  "System.ObjectModel|6.0.0.0",
+                  "System.Reflection.DispatchProxy|6.0.0.0",
+                  "System.Reflection.Emit.ILGeneration|6.0.0.0",
+                  "System.Reflection.Emit.Lightweight|6.0.0.0",
+                  "System.Reflection.Emit|6.0.0.0",
+                  "System.Reflection.Extensions|6.0.0.0",
+                  "System.Reflection.Metadata|6.0.0.0",
+                  "System.Reflection.Primitives|6.0.0.0",
+                  "System.Reflection.TypeExtensions|6.0.0.0",
+                  "System.Reflection|6.0.0.0",
+                  "System.Resources.Reader|6.0.0.0",
+                  "System.Resources.ResourceManager|6.0.0.0",
+                  "System.Resources.Writer|6.0.0.0",
+                  "System.Runtime.CompilerServices.Unsafe|6.0.0.0",
+                  "System.Runtime.CompilerServices.VisualC|6.0.0.0",
+                  "System.Runtime.Extensions|6.0.0.0",
+                  "System.Runtime.Handles|6.0.0.0",
+                  "System.Runtime.InteropServices.RuntimeInformation|6.0.0.0",
+                  "System.Runtime.InteropServices|6.0.0.0",
+                  "System.Runtime.Intrinsics|6.0.0.0",
+                  "System.Runtime.Loader|6.0.0.0",
+                  "System.Runtime.Numerics|6.0.0.0",
+                  "System.Runtime.Serialization.Formatters|6.0.0.0",
+                  "System.Runtime.Serialization.Json|6.0.0.0",
+                  "System.Runtime.Serialization.Primitives|6.0.0.0",
+                  "System.Runtime.Serialization.Xml|6.0.0.0",
+                  "System.Runtime.Serialization|4.0.0.0",
+                  "System.Runtime|6.0.0.0",
+                  "System.Security.AccessControl|6.0.0.0",
+                  "System.Security.Claims|6.0.0.0",
+                  "System.Security.Cryptography.Algorithms|6.0.0.0",
+                  "System.Security.Cryptography.Cng|6.0.0.0",
+                  "System.Security.Cryptography.Csp|6.0.0.0",
+                  "System.Security.Cryptography.Encoding|6.0.0.0",
+                  "System.Security.Cryptography.OpenSsl|6.0.0.0",
+                  "System.Security.Cryptography.Primitives|6.0.0.0",
+                  "System.Security.Cryptography.X509Certificates|6.0.0.0",
+                  "System.Security.Principal.Windows|6.0.0.0",
+                  "System.Security.Principal|6.0.0.0",
+                  "System.Security.SecureString|6.0.0.0",
+                  "System.Security|4.0.0.0",
+                  "System.ServiceModel.Web|4.0.0.0",
+                  "System.ServiceProcess|4.0.0.0",
+                  "System.Text.Encoding.CodePages|6.0.0.0",
+                  "System.Text.Encoding.Extensions|6.0.0.0",
+                  "System.Text.Encoding|6.0.0.0",
+                  "System.Text.Encodings.Web|6.0.0.0",
+                  "System.Text.Json|6.0.0.0",
+                  "System.Text.RegularExpressions|6.0.0.0",
+                  "System.Threading.Channels|6.0.0.0",
+                  "System.Threading.Overlapped|6.0.0.0",
+                  "System.Threading.Tasks.Dataflow|6.0.0.0",
+                  "System.Threading.Tasks.Extensions|6.0.0.0",
+                  "System.Threading.Tasks.Parallel|6.0.0.0",
+                  "System.Threading.Tasks|6.0.0.0",
+                  "System.Threading.Thread|6.0.0.0",
+                  "System.Threading.ThreadPool|6.0.0.0",
+                  "System.Threading.Timer|6.0.0.0",
+                  "System.Threading|6.0.0.0",
+                  "System.Transactions.Local|6.0.0.0",
+                  "System.Transactions|4.0.0.0",
+                  "System.ValueTuple|4.0.3.0",
+                  "System.Web.HttpUtility|6.0.0.0",
+                  "System.Web|4.0.0.0",
+                  "System.Windows|4.0.0.0",
+                  "System.Xml.Linq|4.0.0.0",
+                  "System.Xml.ReaderWriter|6.0.0.0",
+                  "System.Xml.Serialization|4.0.0.0",
+                  "System.Xml.XDocument|6.0.0.0",
+                  "System.Xml.XPath.XDocument|6.0.0.0",
+                  "System.Xml.XPath|6.0.0.0",
+                  "System.Xml.XmlDocument|6.0.0.0",
+                  "System.Xml.XmlSerializer|6.0.0.0",
+                  "System.Xml|4.0.0.0",
+                  "System|4.0.0.0",
+                  "WindowsBase|4.0.0.0",
+                  "mscorlib|4.0.0.0",
+                  "netstandard|2.1.0.0"
+                ],
+                "microsoft.netcore.platforms": [],
+                "microsoft.web.xdt": [],
+                "netstandard.library": [],
+                "netstandard.library.ref": [
+                  "Microsoft.Win32.Primitives|4.0.3.0",
+                  "System.AppContext|4.1.2.0",
+                  "System.Buffers|4.0.3.0",
+                  "System.Collections.Concurrent|4.0.11.0",
+                  "System.Collections.NonGeneric|4.0.3.0",
+                  "System.Collections.Specialized|4.0.3.0",
+                  "System.Collections|4.0.11.0",
+                  "System.ComponentModel.Composition|4.0.0.0",
+                  "System.ComponentModel.EventBasedAsync|4.0.11.0",
+                  "System.ComponentModel.Primitives|4.1.2.0",
+                  "System.ComponentModel.TypeConverter|4.1.2.0",
+                  "System.ComponentModel|4.0.1.0",
+                  "System.Console|4.0.2.0",
+                  "System.Core|4.0.0.0",
+                  "System.Data.Common|4.1.2.0",
+                  "System.Data|4.0.0.0",
+                  "System.Diagnostics.Contracts|4.0.1.0",
+                  "System.Diagnostics.Debug|4.0.11.0",
+                  "System.Diagnostics.FileVersionInfo|4.0.2.0",
+                  "System.Diagnostics.Process|4.1.2.0",
+                  "System.Diagnostics.StackTrace|4.0.4.0",
+                  "System.Diagnostics.TextWriterTraceListener|4.0.2.0",
+                  "System.Diagnostics.Tools|4.0.1.0",
+                  "System.Diagnostics.TraceSource|4.0.2.0",
+                  "System.Diagnostics.Tracing|4.1.2.0",
+                  "System.Drawing.Primitives|4.0.2.0",
+                  "System.Drawing|4.0.0.0",
+                  "System.Dynamic.Runtime|4.0.11.0",
+                  "System.Globalization.Calendars|4.0.3.0",
+                  "System.Globalization.Extensions|4.0.3.0",
+                  "System.Globalization|4.0.11.0",
+                  "System.IO.Compression.FileSystem|4.0.0.0",
+                  "System.IO.Compression.ZipFile|4.0.3.0",
+                  "System.IO.Compression|4.1.3.0",
+                  "System.IO.FileSystem.DriveInfo|4.0.2.0",
+                  "System.IO.FileSystem.Primitives|4.0.3.0",
+                  "System.IO.FileSystem.Watcher|4.0.2.0",
+                  "System.IO.FileSystem|4.0.3.0",
+                  "System.IO.IsolatedStorage|4.0.2.0",
+                  "System.IO.MemoryMappedFiles|4.0.2.0",
+                  "System.IO.Pipes|4.0.2.0",
+                  "System.IO.UnmanagedMemoryStream|4.0.3.0",
+                  "System.IO|4.1.2.0",
+                  "System.Linq.Expressions|4.1.2.0",
+                  "System.Linq.Parallel|4.0.1.0",
+                  "System.Linq.Queryable|4.0.1.0",
+                  "System.Linq|4.1.2.0",
+                  "System.Memory|4.0.2.0",
+                  "System.Net.Http|4.1.2.0",
+                  "System.Net.NameResolution|4.0.2.0",
+                  "System.Net.NetworkInformation|4.1.2.0",
+                  "System.Net.Ping|4.0.2.0",
+                  "System.Net.Primitives|4.0.11.0",
+                  "System.Net.Requests|4.0.11.0",
+                  "System.Net.Security|4.0.2.0",
+                  "System.Net.Sockets|4.1.2.0",
+                  "System.Net.WebHeaderCollection|4.0.1.0",
+                  "System.Net.WebSockets.Client|4.0.2.0",
+                  "System.Net.WebSockets|4.0.2.0",
+                  "System.Net|4.0.0.0",
+                  "System.Numerics.Vectors|4.1.5.0",
+                  "System.Numerics|4.0.0.0",
+                  "System.ObjectModel|4.0.11.0",
+                  "System.Reflection.DispatchProxy|4.0.5.0",
+                  "System.Reflection.Emit.ILGeneration|4.0.1.0",
+                  "System.Reflection.Emit.Lightweight|4.0.1.0",
+                  "System.Reflection.Emit|4.0.1.0",
+                  "System.Reflection.Extensions|4.0.1.0",
+                  "System.Reflection.Primitives|4.0.1.0",
+                  "System.Reflection|4.1.2.0",
+                  "System.Resources.Reader|4.0.2.0",
+                  "System.Resources.ResourceManager|4.0.1.0",
+                  "System.Resources.Writer|4.0.2.0",
+                  "System.Runtime.CompilerServices.VisualC|4.0.2.0",
+                  "System.Runtime.Extensions|4.1.2.0",
+                  "System.Runtime.Handles|4.0.1.0",
+                  "System.Runtime.InteropServices.RuntimeInformation|4.0.2.0",
+                  "System.Runtime.InteropServices|4.1.2.0",
+                  "System.Runtime.Numerics|4.0.1.0",
+                  "System.Runtime.Serialization.Formatters|4.0.2.0",
+                  "System.Runtime.Serialization.Json|4.0.1.0",
+                  "System.Runtime.Serialization.Primitives|4.1.3.0",
+                  "System.Runtime.Serialization.Xml|4.1.3.0",
+                  "System.Runtime.Serialization|4.0.0.0",
+                  "System.Runtime|4.1.2.0",
+                  "System.Security.Claims|4.0.3.0",
+                  "System.Security.Cryptography.Algorithms|4.2.2.0",
+                  "System.Security.Cryptography.Csp|4.0.2.0",
+                  "System.Security.Cryptography.Encoding|4.0.2.0",
+                  "System.Security.Cryptography.Primitives|4.0.2.0",
+                  "System.Security.Cryptography.X509Certificates|4.1.2.0",
+                  "System.Security.Principal|4.0.1.0",
+                  "System.Security.SecureString|4.0.2.0",
+                  "System.ServiceModel.Web|4.0.0.0",
+                  "System.Text.Encoding.Extensions|4.0.11.0",
+                  "System.Text.Encoding|4.0.11.0",
+                  "System.Text.RegularExpressions|4.1.1.0",
+                  "System.Threading.Overlapped|4.0.3.0",
+                  "System.Threading.Tasks.Extensions|4.2.1.0",
+                  "System.Threading.Tasks.Parallel|4.0.1.0",
+                  "System.Threading.Tasks|4.0.11.0",
+                  "System.Threading.Thread|4.0.2.0",
+                  "System.Threading.ThreadPool|4.0.12.0",
+                  "System.Threading.Timer|4.0.1.0",
+                  "System.Threading|4.0.11.0",
+                  "System.Transactions|4.0.0.0",
+                  "System.ValueTuple|4.0.2.0",
+                  "System.Web|4.0.0.0",
+                  "System.Windows|4.0.0.0",
+                  "System.Xml.Linq|4.0.0.0",
+                  "System.Xml.ReaderWriter|4.1.1.0",
+                  "System.Xml.Serialization|4.0.0.0",
+                  "System.Xml.XDocument|4.0.11.0",
+                  "System.Xml.XPath.XDocument|4.0.3.0",
+                  "System.Xml.XPath|4.0.3.0",
+                  "System.Xml.XmlDocument|4.0.3.0",
+                  "System.Xml.XmlSerializer|4.0.11.0",
+                  "System.Xml|4.0.0.0",
+                  "System|4.0.0.0",
+                  "mscorlib|4.0.0.0",
+                  "netstandard|2.1.0.0"
+                ],
+                "newtonsoft.json": [],
+                "nuget.commands": [],
+                "nuget.common": [],
+                "nuget.configuration": [],
+                "nuget.credentials": [],
+                "nuget.dependencyresolver.core": [],
+                "nuget.frameworks": [],
+                "nuget.librarymodel": [],
+                "nuget.packagemanagement": [],
+                "nuget.packaging": [],
+                "nuget.packaging.core": [],
+                "nuget.projectmodel": [],
+                "nuget.protocol": [],
+                "nuget.resolver": [],
+                "nuget.versioning": [],
+                "nunit": [],
+                "nunitlite": [],
+                "system.componentmodel.annotations": [],
+                "system.componentmodel.composition": [],
+                "system.formats.asn1": [],
+                "system.security.cryptography.cng": [],
+                "system.security.cryptography.pkcs": [],
+                "system.security.cryptography.protecteddata": []
+              }
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_dotnet+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "rules_dotnet+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_dotnet+",
+            "rules_dotnet",
+            "rules_dotnet+"
           ]
         ]
       }
@@ -565,6 +3417,365 @@
             "rules_python+",
             "platforms",
             "platforms"
+          ]
+        ]
+      }
+    },
+    "@@rules_rust+//crate_universe:extension.bzl%crate": {
+      "os:osx,arch:aarch64": {
+        "bzlTransitiveDigest": "eULI1IaqDOUe2uM7uXeQTzQn16av50dcWmvVTPwZ+qA=",
+        "usagesDigest": "1ZTRoTd2Ti8pWW4lP/M6QsvMQGl9cOTe9xdnzq8Pbls=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "crates": {
+            "repoRuleId": "@@rules_rust+//crate_universe:extensions.bzl%_generate_repo",
+            "attributes": {
+              "contents": {
+                "BUILD.bazel": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\npackage(default_visibility = [\"//visibility:public\"])\n\nexports_files(\n    [\n        \"cargo-bazel.json\",\n        \"crates.bzl\",\n        \"defs.bzl\",\n    ] + glob(\n        allow_empty = True,\n        include = [\"*.bazel\"],\n    ),\n)\n\nfilegroup(\n    name = \"srcs\",\n    srcs = glob(\n        allow_empty = True,\n        include = [\n            \"*.bazel\",\n            \"*.bzl\",\n        ],\n    ),\n)\n\n# Workspace Member Dependencies\nalias(\n    name = \"googletest\",\n    actual = \"@crates__googletest-0.14.3//:googletest\",\n    tags = [\"manual\"],\n)\n\nalias(\n    name = \"linkme\",\n    actual = \"@crates__linkme-0.3.36//:linkme\",\n    tags = [\"manual\"],\n)\n\nalias(\n    name = \"paste\",\n    actual = \"@crates__paste-1.0.15//:paste\",\n    tags = [\"manual\"],\n)\n\nalias(\n    name = \"quote\",\n    actual = \"@crates__quote-1.0.46//:quote\",\n    tags = [\"manual\"],\n)\n\nalias(\n    name = \"syn\",\n    actual = \"@crates__syn-2.0.118//:syn\",\n    tags = [\"manual\"],\n)\n",
+                "defs.bzl": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\"\"\"\n# `crates_repository` API\n\n- [aliases](#aliases)\n- [crate_deps](#crate_deps)\n- [all_crate_deps](#all_crate_deps)\n- [crate_repositories](#crate_repositories)\n\n\"\"\"\n\nload(\"@bazel_tools//tools/build_defs/repo:git.bzl\", \"new_git_repository\")\nload(\"@bazel_tools//tools/build_defs/repo:http.bzl\", \"http_archive\")\nload(\"@bazel_tools//tools/build_defs/repo:utils.bzl\", \"maybe\")\nload(\"@bazel_skylib//lib:selects.bzl\", \"selects\")\nload(\"@rules_rust//crate_universe/private:local_crate_mirror.bzl\", \"local_crate_mirror\")\n\n###############################################################################\n# MACROS API\n###############################################################################\n\n# An identifier that represent common dependencies (unconditional).\n_COMMON_CONDITION = \"\"\n\ndef _flatten_dependency_maps(all_dependency_maps):\n    \"\"\"Flatten a list of dependency maps into one dictionary.\n\n    Dependency maps have the following structure:\n\n    ```python\n    DEPENDENCIES_MAP = {\n        # The first key in the map is a Bazel package\n        # name of the workspace this file is defined in.\n        \"workspace_member_package\": {\n\n            # Not all dependencies are supported for all platforms.\n            # the condition key is the condition required to be true\n            # on the host platform.\n            \"condition\": {\n\n                # An alias to a crate target.     # The label of the crate target the\n                # Aliases are only crate names.   # package name refers to.\n                \"package_name\":                   \"@full//:label\",\n            }\n        }\n    }\n    ```\n\n    Args:\n        all_dependency_maps (list): A list of dicts as described above\n\n    Returns:\n        dict: A dictionary as described above\n    \"\"\"\n    dependencies = {}\n\n    for workspace_deps_map in all_dependency_maps:\n        for pkg_name, conditional_deps_map in workspace_deps_map.items():\n            if pkg_name not in dependencies:\n                non_frozen_map = dict()\n                for key, values in conditional_deps_map.items():\n                    non_frozen_map.update({key: dict(values.items())})\n                dependencies.setdefault(pkg_name, non_frozen_map)\n                continue\n\n            for condition, deps_map in conditional_deps_map.items():\n                # If the condition has not been recorded, do so and continue\n                if condition not in dependencies[pkg_name]:\n                    dependencies[pkg_name].setdefault(condition, dict(deps_map.items()))\n                    continue\n\n                # Alert on any miss-matched dependencies\n                inconsistent_entries = []\n                for crate_name, crate_label in deps_map.items():\n                    existing = dependencies[pkg_name][condition].get(crate_name)\n                    if existing and existing != crate_label:\n                        inconsistent_entries.append((crate_name, existing, crate_label))\n                    dependencies[pkg_name][condition].update({crate_name: crate_label})\n\n    return dependencies\n\ndef crate_deps(deps, package_name = None):\n    \"\"\"Finds the fully qualified label of the requested crates for the package where this macro is called.\n\n    Args:\n        deps (list): The desired list of crate targets.\n        package_name (str, optional): The package name of the set of dependencies to look up.\n            Defaults to `native.package_name()`.\n\n    Returns:\n        list: A list of labels to generated rust targets (str)\n    \"\"\"\n\n    if not deps:\n        return []\n\n    if package_name == None:\n        package_name = native.package_name()\n\n    # Join both sets of dependencies\n    dependencies = _flatten_dependency_maps([\n        _NORMAL_DEPENDENCIES,\n        _NORMAL_DEV_DEPENDENCIES,\n        _PROC_MACRO_DEPENDENCIES,\n        _PROC_MACRO_DEV_DEPENDENCIES,\n        _BUILD_DEPENDENCIES,\n        _BUILD_PROC_MACRO_DEPENDENCIES,\n    ]).pop(package_name, {})\n\n    # Combine all conditional packages so we can easily index over a flat list\n    # TODO: Perhaps this should actually return select statements and maintain\n    # the conditionals of the dependencies\n    flat_deps = {}\n    for deps_set in dependencies.values():\n        for crate_name, crate_label in deps_set.items():\n            flat_deps.update({crate_name: crate_label})\n\n    missing_crates = []\n    crate_targets = []\n    for crate_target in deps:\n        if crate_target not in flat_deps:\n            missing_crates.append(crate_target)\n        else:\n            crate_targets.append(flat_deps[crate_target])\n\n    if missing_crates:\n        fail(\"Could not find crates `{}` among dependencies of `{}`. Available dependencies were `{}`\".format(\n            missing_crates,\n            package_name,\n            dependencies,\n        ))\n\n    return crate_targets\n\ndef all_crate_deps(\n        normal = False, \n        normal_dev = False, \n        proc_macro = False, \n        proc_macro_dev = False,\n        build = False,\n        build_proc_macro = False,\n        package_name = None):\n    \"\"\"Finds the fully qualified label of all requested direct crate dependencies \\\n    for the package where this macro is called.\n\n    If no parameters are set, all normal dependencies are returned. Setting any one flag will\n    otherwise impact the contents of the returned list.\n\n    Args:\n        normal (bool, optional): If True, normal dependencies are included in the\n            output list.\n        normal_dev (bool, optional): If True, normal dev dependencies will be\n            included in the output list..\n        proc_macro (bool, optional): If True, proc_macro dependencies are included\n            in the output list.\n        proc_macro_dev (bool, optional): If True, dev proc_macro dependencies are\n            included in the output list.\n        build (bool, optional): If True, build dependencies are included\n            in the output list.\n        build_proc_macro (bool, optional): If True, build proc_macro dependencies are\n            included in the output list.\n        package_name (str, optional): The package name of the set of dependencies to look up.\n            Defaults to `native.package_name()` when unset.\n\n    Returns:\n        list: A list of labels to generated rust targets (str)\n    \"\"\"\n\n    if package_name == None:\n        package_name = native.package_name()\n\n    # Determine the relevant maps to use\n    all_dependency_maps = []\n    if normal:\n        all_dependency_maps.append(_NORMAL_DEPENDENCIES)\n    if normal_dev:\n        all_dependency_maps.append(_NORMAL_DEV_DEPENDENCIES)\n    if proc_macro:\n        all_dependency_maps.append(_PROC_MACRO_DEPENDENCIES)\n    if proc_macro_dev:\n        all_dependency_maps.append(_PROC_MACRO_DEV_DEPENDENCIES)\n    if build:\n        all_dependency_maps.append(_BUILD_DEPENDENCIES)\n    if build_proc_macro:\n        all_dependency_maps.append(_BUILD_PROC_MACRO_DEPENDENCIES)\n\n    # Default to always using normal dependencies\n    if not all_dependency_maps:\n        all_dependency_maps.append(_NORMAL_DEPENDENCIES)\n\n    dependencies = _flatten_dependency_maps(all_dependency_maps).pop(package_name, None)\n\n    if not dependencies:\n        if dependencies == None:\n            fail(\"Tried to get all_crate_deps for package \" + package_name + \" but that package had no Cargo.toml file\")\n        else:\n            return []\n\n    crate_deps = list(dependencies.pop(_COMMON_CONDITION, {}).values())\n    for condition, deps in dependencies.items():\n        crate_deps += selects.with_or({\n            tuple(_CONDITIONS[condition]): deps.values(),\n            \"//conditions:default\": [],\n        })\n\n    return crate_deps\n\ndef aliases(\n        normal = False,\n        normal_dev = False,\n        proc_macro = False,\n        proc_macro_dev = False,\n        build = False,\n        build_proc_macro = False,\n        package_name = None):\n    \"\"\"Produces a map of Crate alias names to their original label\n\n    If no dependency kinds are specified, `normal` and `proc_macro` are used by default.\n    Setting any one flag will otherwise determine the contents of the returned dict.\n\n    Args:\n        normal (bool, optional): If True, normal dependencies are included in the\n            output list.\n        normal_dev (bool, optional): If True, normal dev dependencies will be\n            included in the output list..\n        proc_macro (bool, optional): If True, proc_macro dependencies are included\n            in the output list.\n        proc_macro_dev (bool, optional): If True, dev proc_macro dependencies are\n            included in the output list.\n        build (bool, optional): If True, build dependencies are included\n            in the output list.\n        build_proc_macro (bool, optional): If True, build proc_macro dependencies are\n            included in the output list.\n        package_name (str, optional): The package name of the set of dependencies to look up.\n            Defaults to `native.package_name()` when unset.\n\n    Returns:\n        dict: The aliases of all associated packages\n    \"\"\"\n    if package_name == None:\n        package_name = native.package_name()\n\n    # Determine the relevant maps to use\n    all_aliases_maps = []\n    if normal:\n        all_aliases_maps.append(_NORMAL_ALIASES)\n    if normal_dev:\n        all_aliases_maps.append(_NORMAL_DEV_ALIASES)\n    if proc_macro:\n        all_aliases_maps.append(_PROC_MACRO_ALIASES)\n    if proc_macro_dev:\n        all_aliases_maps.append(_PROC_MACRO_DEV_ALIASES)\n    if build:\n        all_aliases_maps.append(_BUILD_ALIASES)\n    if build_proc_macro:\n        all_aliases_maps.append(_BUILD_PROC_MACRO_ALIASES)\n\n    # Default to always using normal aliases\n    if not all_aliases_maps:\n        all_aliases_maps.append(_NORMAL_ALIASES)\n        all_aliases_maps.append(_PROC_MACRO_ALIASES)\n\n    aliases = _flatten_dependency_maps(all_aliases_maps).pop(package_name, None)\n\n    if not aliases:\n        return dict()\n\n    common_items = aliases.pop(_COMMON_CONDITION, {}).items()\n\n    # If there are only common items in the dictionary, immediately return them\n    if not len(aliases.keys()) == 1:\n        return dict(common_items)\n\n    # Build a single select statement where each conditional has accounted for the\n    # common set of aliases.\n    crate_aliases = {\"//conditions:default\": dict(common_items)}\n    for condition, deps in aliases.items():\n        condition_triples = _CONDITIONS[condition]\n        for triple in condition_triples:\n            if triple in crate_aliases:\n                crate_aliases[triple].update(deps)\n            else:\n                crate_aliases.update({triple: dict(deps.items() + common_items)})\n\n    return select(crate_aliases)\n\n###############################################################################\n# WORKSPACE MEMBER DEPS AND ALIASES\n###############################################################################\n\n_NORMAL_DEPENDENCIES = {\n    \"\": {\n        _COMMON_CONDITION: {\n            \"googletest\": Label(\"@crates__googletest-0.14.3//:googletest\"),\n            \"linkme\": Label(\"@crates__linkme-0.3.36//:linkme\"),\n            \"quote\": Label(\"@crates__quote-1.0.46//:quote\"),\n            \"syn\": Label(\"@crates__syn-2.0.118//:syn\"),\n        },\n    },\n}\n\n\n_NORMAL_ALIASES = {\n    \"\": {\n        _COMMON_CONDITION: {\n        },\n    },\n}\n\n\n_NORMAL_DEV_DEPENDENCIES = {\n    \"\": {\n    },\n}\n\n\n_NORMAL_DEV_ALIASES = {\n    \"\": {\n    },\n}\n\n\n_PROC_MACRO_DEPENDENCIES = {\n    \"\": {\n        _COMMON_CONDITION: {\n            \"paste\": Label(\"@crates__paste-1.0.15//:paste\"),\n        },\n    },\n}\n\n\n_PROC_MACRO_ALIASES = {\n    \"\": {\n    },\n}\n\n\n_PROC_MACRO_DEV_DEPENDENCIES = {\n    \"\": {\n    },\n}\n\n\n_PROC_MACRO_DEV_ALIASES = {\n    \"\": {\n    },\n}\n\n\n_BUILD_DEPENDENCIES = {\n    \"\": {\n    },\n}\n\n\n_BUILD_ALIASES = {\n    \"\": {\n    },\n}\n\n\n_BUILD_PROC_MACRO_DEPENDENCIES = {\n    \"\": {\n    },\n}\n\n\n_BUILD_PROC_MACRO_ALIASES = {\n    \"\": {\n    },\n}\n\n\n_CONDITIONS = {\n    \"aarch64-apple-darwin\": [\"@rules_rust//rust/platform:aarch64-apple-darwin\"],\n    \"aarch64-apple-ios\": [\"@rules_rust//rust/platform:aarch64-apple-ios\"],\n    \"aarch64-apple-ios-sim\": [\"@rules_rust//rust/platform:aarch64-apple-ios-sim\"],\n    \"aarch64-linux-android\": [\"@rules_rust//rust/platform:aarch64-linux-android\"],\n    \"aarch64-pc-windows-msvc\": [\"@rules_rust//rust/platform:aarch64-pc-windows-msvc\"],\n    \"aarch64-unknown-fuchsia\": [\"@rules_rust//rust/platform:aarch64-unknown-fuchsia\"],\n    \"aarch64-unknown-linux-gnu\": [\"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\"],\n    \"aarch64-unknown-nixos-gnu\": [\"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\"],\n    \"aarch64-unknown-nto-qnx710\": [\"@rules_rust//rust/platform:aarch64-unknown-nto-qnx710\"],\n    \"arm-unknown-linux-gnueabi\": [\"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\"],\n    \"armv7-linux-androideabi\": [\"@rules_rust//rust/platform:armv7-linux-androideabi\"],\n    \"armv7-unknown-linux-gnueabi\": [\"@rules_rust//rust/platform:armv7-unknown-linux-gnueabi\"],\n    \"i686-apple-darwin\": [\"@rules_rust//rust/platform:i686-apple-darwin\"],\n    \"i686-linux-android\": [\"@rules_rust//rust/platform:i686-linux-android\"],\n    \"i686-pc-windows-msvc\": [\"@rules_rust//rust/platform:i686-pc-windows-msvc\"],\n    \"i686-unknown-freebsd\": [\"@rules_rust//rust/platform:i686-unknown-freebsd\"],\n    \"i686-unknown-linux-gnu\": [\"@rules_rust//rust/platform:i686-unknown-linux-gnu\"],\n    \"powerpc-unknown-linux-gnu\": [\"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\"],\n    \"riscv32imc-unknown-none-elf\": [\"@rules_rust//rust/platform:riscv32imc-unknown-none-elf\"],\n    \"riscv64gc-unknown-none-elf\": [\"@rules_rust//rust/platform:riscv64gc-unknown-none-elf\"],\n    \"s390x-unknown-linux-gnu\": [\"@rules_rust//rust/platform:s390x-unknown-linux-gnu\"],\n    \"thumbv7em-none-eabi\": [\"@rules_rust//rust/platform:thumbv7em-none-eabi\"],\n    \"thumbv8m.main-none-eabi\": [\"@rules_rust//rust/platform:thumbv8m.main-none-eabi\"],\n    \"wasm32-unknown-unknown\": [\"@rules_rust//rust/platform:wasm32-unknown-unknown\"],\n    \"wasm32-wasip1\": [\"@rules_rust//rust/platform:wasm32-wasip1\"],\n    \"x86_64-apple-darwin\": [\"@rules_rust//rust/platform:x86_64-apple-darwin\"],\n    \"x86_64-apple-ios\": [\"@rules_rust//rust/platform:x86_64-apple-ios\"],\n    \"x86_64-linux-android\": [\"@rules_rust//rust/platform:x86_64-linux-android\"],\n    \"x86_64-pc-windows-msvc\": [\"@rules_rust//rust/platform:x86_64-pc-windows-msvc\"],\n    \"x86_64-unknown-freebsd\": [\"@rules_rust//rust/platform:x86_64-unknown-freebsd\"],\n    \"x86_64-unknown-fuchsia\": [\"@rules_rust//rust/platform:x86_64-unknown-fuchsia\"],\n    \"x86_64-unknown-linux-gnu\": [\"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\"],\n    \"x86_64-unknown-nixos-gnu\": [\"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\"],\n    \"x86_64-unknown-none\": [\"@rules_rust//rust/platform:x86_64-unknown-none\"],\n}\n\n###############################################################################\n\ndef crate_repositories():\n    \"\"\"A macro for defining repositories for all generated crates.\n\n    Returns:\n      A list of repos visible to the module through the module extension.\n    \"\"\"\n    maybe(\n        http_archive,\n        name = \"crates__aho-corasick-1.1.4\",\n        sha256 = \"ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/aho-corasick/1.1.4/download\"],\n        strip_prefix = \"aho-corasick-1.1.4\",\n        build_file = Label(\"@crates//crates:BUILD.aho-corasick-1.1.4.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__autocfg-1.5.1\",\n        sha256 = \"f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/autocfg/1.5.1/download\"],\n        strip_prefix = \"autocfg-1.5.1\",\n        build_file = Label(\"@crates//crates:BUILD.autocfg-1.5.1.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__googletest-0.14.3\",\n        sha256 = \"f6b5e2f2b556b7b90297a5a35c8267dd43a537923d2b329beefdba2b4ec19d94\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/googletest/0.14.3/download\"],\n        strip_prefix = \"googletest-0.14.3\",\n        build_file = Label(\"@crates//crates:BUILD.googletest-0.14.3.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__googletest_macro-0.14.3\",\n        sha256 = \"2ae6abc96141edd26bf5aeec0f119c129c44de3ced09e5073711a02cb74725d0\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/googletest_macro/0.14.3/download\"],\n        strip_prefix = \"googletest_macro-0.14.3\",\n        build_file = Label(\"@crates//crates:BUILD.googletest_macro-0.14.3.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__linkme-0.3.36\",\n        sha256 = \"e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/linkme/0.3.36/download\"],\n        strip_prefix = \"linkme-0.3.36\",\n        build_file = Label(\"@crates//crates:BUILD.linkme-0.3.36.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__linkme-impl-0.3.36\",\n        sha256 = \"32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/linkme-impl/0.3.36/download\"],\n        strip_prefix = \"linkme-impl-0.3.36\",\n        build_file = Label(\"@crates//crates:BUILD.linkme-impl-0.3.36.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__memchr-2.8.2\",\n        sha256 = \"88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/memchr/2.8.2/download\"],\n        strip_prefix = \"memchr-2.8.2\",\n        build_file = Label(\"@crates//crates:BUILD.memchr-2.8.2.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__num-traits-0.2.19\",\n        sha256 = \"071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/num-traits/0.2.19/download\"],\n        strip_prefix = \"num-traits-0.2.19\",\n        build_file = Label(\"@crates//crates:BUILD.num-traits-0.2.19.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__paste-1.0.15\",\n        sha256 = \"57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/paste/1.0.15/download\"],\n        strip_prefix = \"paste-1.0.15\",\n        build_file = Label(\"@crates//crates:BUILD.paste-1.0.15.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__proc-macro2-1.0.106\",\n        sha256 = \"8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/proc-macro2/1.0.106/download\"],\n        strip_prefix = \"proc-macro2-1.0.106\",\n        build_file = Label(\"@crates//crates:BUILD.proc-macro2-1.0.106.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__quote-1.0.46\",\n        sha256 = \"dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/quote/1.0.46/download\"],\n        strip_prefix = \"quote-1.0.46\",\n        build_file = Label(\"@crates//crates:BUILD.quote-1.0.46.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__regex-1.12.4\",\n        sha256 = \"f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/regex/1.12.4/download\"],\n        strip_prefix = \"regex-1.12.4\",\n        build_file = Label(\"@crates//crates:BUILD.regex-1.12.4.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__regex-automata-0.4.14\",\n        sha256 = \"6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/regex-automata/0.4.14/download\"],\n        strip_prefix = \"regex-automata-0.4.14\",\n        build_file = Label(\"@crates//crates:BUILD.regex-automata-0.4.14.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__regex-syntax-0.8.11\",\n        sha256 = \"d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/regex-syntax/0.8.11/download\"],\n        strip_prefix = \"regex-syntax-0.8.11\",\n        build_file = Label(\"@crates//crates:BUILD.regex-syntax-0.8.11.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__rustversion-1.0.22\",\n        sha256 = \"b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/rustversion/1.0.22/download\"],\n        strip_prefix = \"rustversion-1.0.22\",\n        build_file = Label(\"@crates//crates:BUILD.rustversion-1.0.22.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__syn-2.0.118\",\n        sha256 = \"1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/syn/2.0.118/download\"],\n        strip_prefix = \"syn-2.0.118\",\n        build_file = Label(\"@crates//crates:BUILD.syn-2.0.118.bazel\"),\n    )\n\n    maybe(\n        http_archive,\n        name = \"crates__unicode-ident-1.0.24\",\n        sha256 = \"e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75\",\n        type = \"tar.gz\",\n        urls = [\"https://static.crates.io/crates/unicode-ident/1.0.24/download\"],\n        strip_prefix = \"unicode-ident-1.0.24\",\n        build_file = Label(\"@crates//crates:BUILD.unicode-ident-1.0.24.bazel\"),\n    )\n\n    return [\n       struct(repo=\"crates__googletest-0.14.3\", is_dev_dep = False),\n       struct(repo=\"crates__linkme-0.3.36\", is_dev_dep = False),\n       struct(repo=\"crates__paste-1.0.15\", is_dev_dep = False),\n       struct(repo=\"crates__quote-1.0.46\", is_dev_dep = False),\n       struct(repo=\"crates__syn-2.0.118\", is_dev_dep = False),\n    ]\n"
+              }
+            }
+          },
+          "crates__aho-corasick-1.1.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "patch_args": [],
+              "patch_tool": "",
+              "patches": [],
+              "remote_patch_strip": 1,
+              "sha256": "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/aho-corasick/1.1.4/download"
+              ],
+              "strip_prefix": "aho-corasick-1.1.4",
+              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"aho_corasick\",\n    deps = [\n        \"@crates__memchr-2.8.2//:memchr\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"perf-literal\",\n        \"std\",\n    ],\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=aho-corasick\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios-sim\": [],\n        \"@rules_rust//rust/platform:aarch64-linux-android\": [],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nto-qnx710\": [],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:armv7-linux-androideabi\": [],\n        \"@rules_rust//rust/platform:armv7-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:i686-apple-darwin\": [],\n        \"@rules_rust//rust/platform:i686-linux-android\": [],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:i686-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:riscv32imc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:riscv64gc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:thumbv7em-none-eabi\": [],\n        \"@rules_rust//rust/platform:thumbv8m.main-none-eabi\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-ios\": [],\n        \"@rules_rust//rust/platform:x86_64-linux-android\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-none\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"1.1.4\",\n)\n"
+            }
+          },
+          "crates__autocfg-1.5.1": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "patch_args": [],
+              "patch_tool": "",
+              "patches": [],
+              "remote_patch_strip": 1,
+              "sha256": "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/autocfg/1.5.1/download"
+              ],
+              "strip_prefix": "autocfg-1.5.1",
+              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"autocfg\",\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_root = \"src/lib.rs\",\n    edition = \"2015\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=autocfg\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios-sim\": [],\n        \"@rules_rust//rust/platform:aarch64-linux-android\": [],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nto-qnx710\": [],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:armv7-linux-androideabi\": [],\n        \"@rules_rust//rust/platform:armv7-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:i686-apple-darwin\": [],\n        \"@rules_rust//rust/platform:i686-linux-android\": [],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:i686-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:riscv32imc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:riscv64gc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:thumbv7em-none-eabi\": [],\n        \"@rules_rust//rust/platform:thumbv8m.main-none-eabi\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-ios\": [],\n        \"@rules_rust//rust/platform:x86_64-linux-android\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-none\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"1.5.1\",\n)\n"
+            }
+          },
+          "crates__googletest-0.14.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "patch_args": [],
+              "patch_tool": "",
+              "patches": [],
+              "remote_patch_strip": 1,
+              "sha256": "f6b5e2f2b556b7b90297a5a35c8267dd43a537923d2b329beefdba2b4ec19d94",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/googletest/0.14.3/download"
+              ],
+              "strip_prefix": "googletest-0.14.3",
+              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"googletest\",\n    deps = [\n        \"@crates__num-traits-0.2.19//:num_traits\",\n        \"@crates__regex-1.12.4//:regex\",\n    ],\n    proc_macro_deps = [\n        \"@crates__googletest_macro-0.14.3//:googletest_macro\",\n        \"@crates__rustversion-1.0.22//:rustversion\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=googletest\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios-sim\": [],\n        \"@rules_rust//rust/platform:aarch64-linux-android\": [],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nto-qnx710\": [],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:armv7-linux-androideabi\": [],\n        \"@rules_rust//rust/platform:armv7-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:i686-apple-darwin\": [],\n        \"@rules_rust//rust/platform:i686-linux-android\": [],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:i686-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:riscv32imc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:riscv64gc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:thumbv7em-none-eabi\": [],\n        \"@rules_rust//rust/platform:thumbv8m.main-none-eabi\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-ios\": [],\n        \"@rules_rust//rust/platform:x86_64-linux-android\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-none\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"0.14.3\",\n)\n"
+            }
+          },
+          "crates__googletest_macro-0.14.3": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "patch_args": [],
+              "patch_tool": "",
+              "patches": [],
+              "remote_patch_strip": 1,
+              "sha256": "2ae6abc96141edd26bf5aeec0f119c129c44de3ced09e5073711a02cb74725d0",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/googletest_macro/0.14.3/download"
+              ],
+              "strip_prefix": "googletest_macro-0.14.3",
+              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_proc_macro\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_proc_macro(\n    name = \"googletest_macro\",\n    deps = [\n        \"@crates__proc-macro2-1.0.106//:proc_macro2\",\n        \"@crates__quote-1.0.46//:quote\",\n        \"@crates__syn-2.0.118//:syn\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=googletest_macro\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios-sim\": [],\n        \"@rules_rust//rust/platform:aarch64-linux-android\": [],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nto-qnx710\": [],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:armv7-linux-androideabi\": [],\n        \"@rules_rust//rust/platform:armv7-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:i686-apple-darwin\": [],\n        \"@rules_rust//rust/platform:i686-linux-android\": [],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:i686-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:riscv32imc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:riscv64gc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:thumbv7em-none-eabi\": [],\n        \"@rules_rust//rust/platform:thumbv8m.main-none-eabi\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-ios\": [],\n        \"@rules_rust//rust/platform:x86_64-linux-android\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-none\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"0.14.3\",\n)\n"
+            }
+          },
+          "crates__linkme-0.3.36": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "patch_args": [],
+              "patch_tool": "",
+              "patches": [],
+              "remote_patch_strip": 1,
+              "sha256": "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/linkme/0.3.36/download"
+              ],
+              "strip_prefix": "linkme-0.3.36",
+              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\nload(\"@rules_rust//cargo:defs.bzl\", \"cargo_build_script\")\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"linkme\",\n    deps = [\n        \"@crates__linkme-0.3.36//:build_script_build\",\n    ],\n    proc_macro_deps = [\n        \"@crates__linkme-impl-0.3.36//:linkme_impl\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=linkme\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios-sim\": [],\n        \"@rules_rust//rust/platform:aarch64-linux-android\": [],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nto-qnx710\": [],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:armv7-linux-androideabi\": [],\n        \"@rules_rust//rust/platform:armv7-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:i686-apple-darwin\": [],\n        \"@rules_rust//rust/platform:i686-linux-android\": [],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:i686-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:riscv32imc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:riscv64gc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:thumbv7em-none-eabi\": [],\n        \"@rules_rust//rust/platform:thumbv8m.main-none-eabi\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-ios\": [],\n        \"@rules_rust//rust/platform:x86_64-linux-android\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-none\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"0.3.36\",\n)\n\ncargo_build_script(\n    name = \"_bs\",\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"**/*.rs\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_name = \"build_script_build\",\n    crate_root = \"build.rs\",\n    data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    edition = \"2021\",\n    pkg_name = \"linkme\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=linkme\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.3.36\",\n    visibility = [\"//visibility:private\"],\n)\n\nalias(\n    name = \"build_script_build\",\n    actual = \":_bs\",\n    tags = [\"manual\"],\n)\n"
+            }
+          },
+          "crates__linkme-impl-0.3.36": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "patch_args": [],
+              "patch_tool": "",
+              "patches": [],
+              "remote_patch_strip": 1,
+              "sha256": "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/linkme-impl/0.3.36/download"
+              ],
+              "strip_prefix": "linkme-impl-0.3.36",
+              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\nload(\"@rules_rust//cargo:defs.bzl\", \"cargo_build_script\")\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_proc_macro\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_proc_macro(\n    name = \"linkme_impl\",\n    deps = [\n        \"@crates__linkme-impl-0.3.36//:build_script_build\",\n        \"@crates__proc-macro2-1.0.106//:proc_macro2\",\n        \"@crates__quote-1.0.46//:quote\",\n        \"@crates__syn-2.0.118//:syn\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=linkme-impl\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios-sim\": [],\n        \"@rules_rust//rust/platform:aarch64-linux-android\": [],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nto-qnx710\": [],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:armv7-linux-androideabi\": [],\n        \"@rules_rust//rust/platform:armv7-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:i686-apple-darwin\": [],\n        \"@rules_rust//rust/platform:i686-linux-android\": [],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:i686-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:riscv32imc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:riscv64gc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:thumbv7em-none-eabi\": [],\n        \"@rules_rust//rust/platform:thumbv8m.main-none-eabi\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-ios\": [],\n        \"@rules_rust//rust/platform:x86_64-linux-android\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-none\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"0.3.36\",\n)\n\ncargo_build_script(\n    name = \"_bs\",\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"**/*.rs\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_name = \"build_script_build\",\n    crate_root = \"build.rs\",\n    data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    edition = \"2021\",\n    pkg_name = \"linkme-impl\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=linkme-impl\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.3.36\",\n    visibility = [\"//visibility:private\"],\n)\n\nalias(\n    name = \"build_script_build\",\n    actual = \":_bs\",\n    tags = [\"manual\"],\n)\n"
+            }
+          },
+          "crates__memchr-2.8.2": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "patch_args": [],
+              "patch_tool": "",
+              "patches": [],
+              "remote_patch_strip": 1,
+              "sha256": "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/memchr/2.8.2/download"
+              ],
+              "strip_prefix": "memchr-2.8.2",
+              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"memchr\",\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"alloc\",\n        \"std\",\n    ],\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=memchr\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios-sim\": [],\n        \"@rules_rust//rust/platform:aarch64-linux-android\": [],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nto-qnx710\": [],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:armv7-linux-androideabi\": [],\n        \"@rules_rust//rust/platform:armv7-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:i686-apple-darwin\": [],\n        \"@rules_rust//rust/platform:i686-linux-android\": [],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:i686-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:riscv32imc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:riscv64gc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:thumbv7em-none-eabi\": [],\n        \"@rules_rust//rust/platform:thumbv8m.main-none-eabi\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-ios\": [],\n        \"@rules_rust//rust/platform:x86_64-linux-android\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-none\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"2.8.2\",\n)\n"
+            }
+          },
+          "crates__num-traits-0.2.19": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "patch_args": [],
+              "patch_tool": "",
+              "patches": [],
+              "remote_patch_strip": 1,
+              "sha256": "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/num-traits/0.2.19/download"
+              ],
+              "strip_prefix": "num-traits-0.2.19",
+              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\nload(\"@rules_rust//cargo:defs.bzl\", \"cargo_build_script\")\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"num_traits\",\n    deps = [\n        \"@crates__num-traits-0.2.19//:build_script_build\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"default\",\n        \"std\",\n    ],\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=num-traits\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios-sim\": [],\n        \"@rules_rust//rust/platform:aarch64-linux-android\": [],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nto-qnx710\": [],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:armv7-linux-androideabi\": [],\n        \"@rules_rust//rust/platform:armv7-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:i686-apple-darwin\": [],\n        \"@rules_rust//rust/platform:i686-linux-android\": [],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:i686-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:riscv32imc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:riscv64gc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:thumbv7em-none-eabi\": [],\n        \"@rules_rust//rust/platform:thumbv8m.main-none-eabi\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-ios\": [],\n        \"@rules_rust//rust/platform:x86_64-linux-android\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-none\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"0.2.19\",\n)\n\ncargo_build_script(\n    name = \"_bs\",\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"**/*.rs\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"default\",\n        \"std\",\n    ],\n    crate_name = \"build_script_build\",\n    crate_root = \"build.rs\",\n    data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    deps = [\n        \"@crates__autocfg-1.5.1//:autocfg\",\n    ],\n    edition = \"2021\",\n    pkg_name = \"num-traits\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=num-traits\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.2.19\",\n    visibility = [\"//visibility:private\"],\n)\n\nalias(\n    name = \"build_script_build\",\n    actual = \":_bs\",\n    tags = [\"manual\"],\n)\n"
+            }
+          },
+          "crates__paste-1.0.15": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "patch_args": [],
+              "patch_tool": "",
+              "patches": [],
+              "remote_patch_strip": 1,
+              "sha256": "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/paste/1.0.15/download"
+              ],
+              "strip_prefix": "paste-1.0.15",
+              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\nload(\"@rules_rust//cargo:defs.bzl\", \"cargo_build_script\")\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_proc_macro\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_proc_macro(\n    name = \"paste\",\n    deps = [\n        \"@crates__paste-1.0.15//:build_script_build\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_root = \"src/lib.rs\",\n    edition = \"2018\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=paste\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios-sim\": [],\n        \"@rules_rust//rust/platform:aarch64-linux-android\": [],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nto-qnx710\": [],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:armv7-linux-androideabi\": [],\n        \"@rules_rust//rust/platform:armv7-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:i686-apple-darwin\": [],\n        \"@rules_rust//rust/platform:i686-linux-android\": [],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:i686-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:riscv32imc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:riscv64gc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:thumbv7em-none-eabi\": [],\n        \"@rules_rust//rust/platform:thumbv8m.main-none-eabi\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-ios\": [],\n        \"@rules_rust//rust/platform:x86_64-linux-android\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-none\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"1.0.15\",\n)\n\ncargo_build_script(\n    name = \"_bs\",\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"**/*.rs\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_name = \"build_script_build\",\n    crate_root = \"build.rs\",\n    data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    edition = \"2018\",\n    pkg_name = \"paste\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=paste\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"1.0.15\",\n    visibility = [\"//visibility:private\"],\n)\n\nalias(\n    name = \"build_script_build\",\n    actual = \":_bs\",\n    tags = [\"manual\"],\n)\n"
+            }
+          },
+          "crates__proc-macro2-1.0.106": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "patch_args": [],
+              "patch_tool": "",
+              "patches": [],
+              "remote_patch_strip": 1,
+              "sha256": "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/proc-macro2/1.0.106/download"
+              ],
+              "strip_prefix": "proc-macro2-1.0.106",
+              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\nload(\"@rules_rust//cargo:defs.bzl\", \"cargo_build_script\")\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"proc_macro2\",\n    deps = [\n        \"@crates__proc-macro2-1.0.106//:build_script_build\",\n        \"@crates__unicode-ident-1.0.24//:unicode_ident\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"proc-macro\",\n    ] + select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [\n            \"default\",  # aarch64-apple-darwin\n        ],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [\n            \"default\",  # aarch64-pc-windows-msvc\n        ],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [\n            \"default\",  # aarch64-unknown-linux-gnu\n        ],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [\n            \"default\",  # aarch64-unknown-nixos-gnu\n        ],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [\n            \"default\",  # arm-unknown-linux-gnueabi\n        ],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [\n            \"default\",  # i686-pc-windows-msvc\n        ],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [\n            \"default\",  # i686-unknown-linux-gnu\n        ],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [\n            \"default\",  # powerpc-unknown-linux-gnu\n        ],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [\n            \"default\",  # s390x-unknown-linux-gnu\n        ],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [\n            \"default\",  # x86_64-apple-darwin\n        ],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [\n            \"default\",  # x86_64-pc-windows-msvc\n        ],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [\n            \"default\",  # x86_64-unknown-freebsd\n        ],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [\n            \"default\",  # x86_64-unknown-linux-gnu\n        ],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [\n            \"default\",  # x86_64-unknown-nixos-gnu\n        ],\n        \"//conditions:default\": [],\n    }),\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=proc-macro2\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios-sim\": [],\n        \"@rules_rust//rust/platform:aarch64-linux-android\": [],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nto-qnx710\": [],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:armv7-linux-androideabi\": [],\n        \"@rules_rust//rust/platform:armv7-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:i686-apple-darwin\": [],\n        \"@rules_rust//rust/platform:i686-linux-android\": [],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:i686-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:riscv32imc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:riscv64gc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:thumbv7em-none-eabi\": [],\n        \"@rules_rust//rust/platform:thumbv8m.main-none-eabi\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-ios\": [],\n        \"@rules_rust//rust/platform:x86_64-linux-android\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-none\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"1.0.106\",\n)\n\ncargo_build_script(\n    name = \"_bs\",\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"**/*.rs\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"proc-macro\",\n    ] + select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [\n            \"default\",  # aarch64-apple-darwin\n        ],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [\n            \"default\",  # aarch64-pc-windows-msvc\n        ],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [\n            \"default\",  # aarch64-unknown-linux-gnu\n        ],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [\n            \"default\",  # aarch64-unknown-nixos-gnu\n        ],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [\n            \"default\",  # arm-unknown-linux-gnueabi\n        ],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [\n            \"default\",  # i686-pc-windows-msvc\n        ],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [\n            \"default\",  # i686-unknown-linux-gnu\n        ],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [\n            \"default\",  # powerpc-unknown-linux-gnu\n        ],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [\n            \"default\",  # s390x-unknown-linux-gnu\n        ],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [\n            \"default\",  # x86_64-apple-darwin\n        ],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [\n            \"default\",  # x86_64-pc-windows-msvc\n        ],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [\n            \"default\",  # x86_64-unknown-freebsd\n        ],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [\n            \"default\",  # x86_64-unknown-linux-gnu\n        ],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [\n            \"default\",  # x86_64-unknown-nixos-gnu\n        ],\n        \"//conditions:default\": [],\n    }),\n    crate_name = \"build_script_build\",\n    crate_root = \"build.rs\",\n    data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    edition = \"2021\",\n    pkg_name = \"proc-macro2\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=proc-macro2\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"1.0.106\",\n    visibility = [\"//visibility:private\"],\n)\n\nalias(\n    name = \"build_script_build\",\n    actual = \":_bs\",\n    tags = [\"manual\"],\n)\n"
+            }
+          },
+          "crates__quote-1.0.46": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "patch_args": [],
+              "patch_tool": "",
+              "patches": [],
+              "remote_patch_strip": 1,
+              "sha256": "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/quote/1.0.46/download"
+              ],
+              "strip_prefix": "quote-1.0.46",
+              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\nload(\"@rules_rust//cargo:defs.bzl\", \"cargo_build_script\")\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"quote\",\n    deps = [\n        \"@crates__proc-macro2-1.0.106//:proc_macro2\",\n        \"@crates__quote-1.0.46//:build_script_build\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"default\",\n        \"proc-macro\",\n    ],\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=quote\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios-sim\": [],\n        \"@rules_rust//rust/platform:aarch64-linux-android\": [],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nto-qnx710\": [],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:armv7-linux-androideabi\": [],\n        \"@rules_rust//rust/platform:armv7-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:i686-apple-darwin\": [],\n        \"@rules_rust//rust/platform:i686-linux-android\": [],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:i686-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:riscv32imc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:riscv64gc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:thumbv7em-none-eabi\": [],\n        \"@rules_rust//rust/platform:thumbv8m.main-none-eabi\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-ios\": [],\n        \"@rules_rust//rust/platform:x86_64-linux-android\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-none\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"1.0.46\",\n)\n\ncargo_build_script(\n    name = \"_bs\",\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"**/*.rs\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"default\",\n        \"proc-macro\",\n    ],\n    crate_name = \"build_script_build\",\n    crate_root = \"build.rs\",\n    data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    edition = \"2021\",\n    pkg_name = \"quote\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=quote\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"1.0.46\",\n    visibility = [\"//visibility:private\"],\n)\n\nalias(\n    name = \"build_script_build\",\n    actual = \":_bs\",\n    tags = [\"manual\"],\n)\n"
+            }
+          },
+          "crates__regex-1.12.4": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "patch_args": [],
+              "patch_tool": "",
+              "patches": [],
+              "remote_patch_strip": 1,
+              "sha256": "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex/1.12.4/download"
+              ],
+              "strip_prefix": "regex-1.12.4",
+              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"regex\",\n    deps = [\n        \"@crates__aho-corasick-1.1.4//:aho_corasick\",\n        \"@crates__memchr-2.8.2//:memchr\",\n        \"@crates__regex-automata-0.4.14//:regex_automata\",\n        \"@crates__regex-syntax-0.8.11//:regex_syntax\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"default\",\n        \"perf\",\n        \"perf-backtrack\",\n        \"perf-cache\",\n        \"perf-dfa\",\n        \"perf-inline\",\n        \"perf-literal\",\n        \"perf-onepass\",\n        \"std\",\n        \"unicode\",\n        \"unicode-age\",\n        \"unicode-bool\",\n        \"unicode-case\",\n        \"unicode-gencat\",\n        \"unicode-perl\",\n        \"unicode-script\",\n        \"unicode-segment\",\n    ],\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=regex\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios-sim\": [],\n        \"@rules_rust//rust/platform:aarch64-linux-android\": [],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nto-qnx710\": [],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:armv7-linux-androideabi\": [],\n        \"@rules_rust//rust/platform:armv7-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:i686-apple-darwin\": [],\n        \"@rules_rust//rust/platform:i686-linux-android\": [],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:i686-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:riscv32imc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:riscv64gc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:thumbv7em-none-eabi\": [],\n        \"@rules_rust//rust/platform:thumbv8m.main-none-eabi\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-ios\": [],\n        \"@rules_rust//rust/platform:x86_64-linux-android\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-none\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"1.12.4\",\n)\n"
+            }
+          },
+          "crates__regex-automata-0.4.14": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "patch_args": [],
+              "patch_tool": "",
+              "patches": [],
+              "remote_patch_strip": 1,
+              "sha256": "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-automata/0.4.14/download"
+              ],
+              "strip_prefix": "regex-automata-0.4.14",
+              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"regex_automata\",\n    deps = [\n        \"@crates__aho-corasick-1.1.4//:aho_corasick\",\n        \"@crates__memchr-2.8.2//:memchr\",\n        \"@crates__regex-syntax-0.8.11//:regex_syntax\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"alloc\",\n        \"dfa-onepass\",\n        \"hybrid\",\n        \"meta\",\n        \"nfa-backtrack\",\n        \"nfa-pikevm\",\n        \"nfa-thompson\",\n        \"perf-inline\",\n        \"perf-literal\",\n        \"perf-literal-multisubstring\",\n        \"perf-literal-substring\",\n        \"std\",\n        \"syntax\",\n        \"unicode\",\n        \"unicode-age\",\n        \"unicode-bool\",\n        \"unicode-case\",\n        \"unicode-gencat\",\n        \"unicode-perl\",\n        \"unicode-script\",\n        \"unicode-segment\",\n        \"unicode-word-boundary\",\n    ],\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=regex-automata\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios-sim\": [],\n        \"@rules_rust//rust/platform:aarch64-linux-android\": [],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nto-qnx710\": [],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:armv7-linux-androideabi\": [],\n        \"@rules_rust//rust/platform:armv7-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:i686-apple-darwin\": [],\n        \"@rules_rust//rust/platform:i686-linux-android\": [],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:i686-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:riscv32imc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:riscv64gc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:thumbv7em-none-eabi\": [],\n        \"@rules_rust//rust/platform:thumbv8m.main-none-eabi\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-ios\": [],\n        \"@rules_rust//rust/platform:x86_64-linux-android\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-none\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"0.4.14\",\n)\n"
+            }
+          },
+          "crates__regex-syntax-0.8.11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "patch_args": [],
+              "patch_tool": "",
+              "patches": [],
+              "remote_patch_strip": 1,
+              "sha256": "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/regex-syntax/0.8.11/download"
+              ],
+              "strip_prefix": "regex-syntax-0.8.11",
+              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"regex_syntax\",\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"default\",\n        \"std\",\n        \"unicode\",\n        \"unicode-age\",\n        \"unicode-bool\",\n        \"unicode-case\",\n        \"unicode-gencat\",\n        \"unicode-perl\",\n        \"unicode-script\",\n        \"unicode-segment\",\n    ],\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=regex-syntax\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios-sim\": [],\n        \"@rules_rust//rust/platform:aarch64-linux-android\": [],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nto-qnx710\": [],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:armv7-linux-androideabi\": [],\n        \"@rules_rust//rust/platform:armv7-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:i686-apple-darwin\": [],\n        \"@rules_rust//rust/platform:i686-linux-android\": [],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:i686-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:riscv32imc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:riscv64gc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:thumbv7em-none-eabi\": [],\n        \"@rules_rust//rust/platform:thumbv8m.main-none-eabi\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-ios\": [],\n        \"@rules_rust//rust/platform:x86_64-linux-android\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-none\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"0.8.11\",\n)\n"
+            }
+          },
+          "crates__rustversion-1.0.22": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "patch_args": [],
+              "patch_tool": "",
+              "patches": [],
+              "remote_patch_strip": 1,
+              "sha256": "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/rustversion/1.0.22/download"
+              ],
+              "strip_prefix": "rustversion-1.0.22",
+              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\nload(\"@rules_rust//cargo:defs.bzl\", \"cargo_build_script\")\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_proc_macro\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_proc_macro(\n    name = \"rustversion\",\n    deps = [\n        \"@crates__rustversion-1.0.22//:build_script_build\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_root = \"src/lib.rs\",\n    edition = \"2018\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=rustversion\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios-sim\": [],\n        \"@rules_rust//rust/platform:aarch64-linux-android\": [],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nto-qnx710\": [],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:armv7-linux-androideabi\": [],\n        \"@rules_rust//rust/platform:armv7-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:i686-apple-darwin\": [],\n        \"@rules_rust//rust/platform:i686-linux-android\": [],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:i686-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:riscv32imc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:riscv64gc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:thumbv7em-none-eabi\": [],\n        \"@rules_rust//rust/platform:thumbv8m.main-none-eabi\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-ios\": [],\n        \"@rules_rust//rust/platform:x86_64-linux-android\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-none\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"1.0.22\",\n)\n\ncargo_build_script(\n    name = \"_bs\",\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"**/*.rs\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_name = \"build_script_build\",\n    crate_root = \"build/build.rs\",\n    data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    edition = \"2018\",\n    pkg_name = \"rustversion\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=rustversion\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"1.0.22\",\n    visibility = [\"//visibility:private\"],\n)\n\nalias(\n    name = \"build_script_build\",\n    actual = \":_bs\",\n    tags = [\"manual\"],\n)\n"
+            }
+          },
+          "crates__syn-2.0.118": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "patch_args": [],
+              "patch_tool": "",
+              "patches": [],
+              "remote_patch_strip": 1,
+              "sha256": "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/syn/2.0.118/download"
+              ],
+              "strip_prefix": "syn-2.0.118",
+              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"syn\",\n    deps = [\n        \"@crates__proc-macro2-1.0.106//:proc_macro2\",\n        \"@crates__quote-1.0.46//:quote\",\n        \"@crates__unicode-ident-1.0.24//:unicode_ident\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_features = [\n        \"clone-impls\",\n        \"default\",\n        \"derive\",\n        \"parsing\",\n        \"printing\",\n        \"proc-macro\",\n    ] + select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [\n            \"extra-traits\",  # aarch64-apple-darwin\n            \"full\",  # aarch64-apple-darwin\n        ],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [\n            \"extra-traits\",  # aarch64-pc-windows-msvc\n            \"full\",  # aarch64-pc-windows-msvc\n        ],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [\n            \"extra-traits\",  # aarch64-unknown-linux-gnu\n            \"full\",  # aarch64-unknown-linux-gnu\n        ],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [\n            \"extra-traits\",  # aarch64-unknown-nixos-gnu\n            \"full\",  # aarch64-unknown-nixos-gnu\n        ],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [\n            \"extra-traits\",  # arm-unknown-linux-gnueabi\n            \"full\",  # arm-unknown-linux-gnueabi\n        ],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [\n            \"extra-traits\",  # i686-pc-windows-msvc\n            \"full\",  # i686-pc-windows-msvc\n        ],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [\n            \"extra-traits\",  # i686-unknown-linux-gnu\n            \"full\",  # i686-unknown-linux-gnu\n        ],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [\n            \"extra-traits\",  # powerpc-unknown-linux-gnu\n            \"full\",  # powerpc-unknown-linux-gnu\n        ],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [\n            \"extra-traits\",  # s390x-unknown-linux-gnu\n            \"full\",  # s390x-unknown-linux-gnu\n        ],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [\n            \"extra-traits\",  # x86_64-apple-darwin\n            \"full\",  # x86_64-apple-darwin\n        ],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [\n            \"extra-traits\",  # x86_64-pc-windows-msvc\n            \"full\",  # x86_64-pc-windows-msvc\n        ],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [\n            \"extra-traits\",  # x86_64-unknown-freebsd\n            \"full\",  # x86_64-unknown-freebsd\n        ],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [\n            \"extra-traits\",  # x86_64-unknown-linux-gnu\n            \"full\",  # x86_64-unknown-linux-gnu\n        ],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [\n            \"extra-traits\",  # x86_64-unknown-nixos-gnu\n            \"full\",  # x86_64-unknown-nixos-gnu\n        ],\n        \"//conditions:default\": [],\n    }),\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=syn\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios-sim\": [],\n        \"@rules_rust//rust/platform:aarch64-linux-android\": [],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nto-qnx710\": [],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:armv7-linux-androideabi\": [],\n        \"@rules_rust//rust/platform:armv7-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:i686-apple-darwin\": [],\n        \"@rules_rust//rust/platform:i686-linux-android\": [],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:i686-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:riscv32imc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:riscv64gc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:thumbv7em-none-eabi\": [],\n        \"@rules_rust//rust/platform:thumbv8m.main-none-eabi\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-ios\": [],\n        \"@rules_rust//rust/platform:x86_64-linux-android\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-none\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"2.0.118\",\n)\n"
+            }
+          },
+          "crates__unicode-ident-1.0.24": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "patch_args": [],
+              "patch_tool": "",
+              "patches": [],
+              "remote_patch_strip": 1,
+              "sha256": "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/unicode-ident/1.0.24/download"
+              ],
+              "strip_prefix": "unicode-ident-1.0.24",
+              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     Run 'cargo update [--workspace]'\n###############################################################################\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\nrust_library(\n    name = \"unicode_ident\",\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=unicode-ident\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios\": [],\n        \"@rules_rust//rust/platform:aarch64-apple-ios-sim\": [],\n        \"@rules_rust//rust/platform:aarch64-linux-android\": [],\n        \"@rules_rust//rust/platform:aarch64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-nto-qnx710\": [],\n        \"@rules_rust//rust/platform:arm-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:armv7-linux-androideabi\": [],\n        \"@rules_rust//rust/platform:armv7-unknown-linux-gnueabi\": [],\n        \"@rules_rust//rust/platform:i686-apple-darwin\": [],\n        \"@rules_rust//rust/platform:i686-linux-android\": [],\n        \"@rules_rust//rust/platform:i686-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:i686-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:i686-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:powerpc-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:riscv32imc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:riscv64gc-unknown-none-elf\": [],\n        \"@rules_rust//rust/platform:s390x-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:thumbv7em-none-eabi\": [],\n        \"@rules_rust//rust/platform:thumbv8m.main-none-eabi\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:x86_64-apple-ios\": [],\n        \"@rules_rust//rust/platform:x86_64-linux-android\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-freebsd\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-fuchsia\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-none\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"1.0.24\",\n)\n"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "bazel_features+",
+            "bazel_features_globals",
+            "bazel_features++version_extension+bazel_features_globals"
+          ],
+          [
+            "bazel_features+",
+            "bazel_features_version",
+            "bazel_features++version_extension+bazel_features_version"
+          ],
+          [
+            "bazel_tools",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_cc+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_cc+",
+            "cc_compatibility_proxy",
+            "rules_cc++compatibility_proxy+cc_compatibility_proxy"
+          ],
+          [
+            "rules_cc+",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_cc++compatibility_proxy+cc_compatibility_proxy",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_rust+",
+            "bazel_features",
+            "bazel_features+"
+          ],
+          [
+            "rules_rust+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "rules_rust+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_rust+",
+            "cargo_bazel_bootstrap",
+            "rules_rust++cu+cargo_bazel_bootstrap"
+          ],
+          [
+            "rules_rust+",
+            "rules_rust",
+            "rules_rust+"
+          ],
+          [
+            "rules_rust+",
+            "rust_host_tools",
+            "rules_rust++rust_host_tools+rust_host_tools"
           ]
         ]
       }

--- a/tool/ide/RustManifestSyncer.kt
+++ b/tool/ide/RustManifestSyncer.kt
@@ -7,7 +7,6 @@
 package com.typedb.dependencies.tool.ide
 
 import com.eclipsesource.json.Json
-import com.eclipsesource.json.JsonObject
 import com.electronwill.nightconfig.core.Config
 import com.electronwill.nightconfig.toml.TomlWriter
 import com.typedb.bazel.distribution.common.Logging.LogLevel.DEBUG
@@ -21,14 +20,15 @@ import com.typedb.dependencies.tool.ide.RustManifestSyncer.ShellArgs.BAZEL_BIN
 import com.typedb.dependencies.tool.ide.RustManifestSyncer.ShellArgs.BUILD
 import com.typedb.dependencies.tool.ide.RustManifestSyncer.ShellArgs.CQUERY
 import com.typedb.dependencies.tool.ide.RustManifestSyncer.ShellArgs.INFO
+import com.typedb.dependencies.tool.ide.RustManifestSyncer.ShellArgs.MOD
 import com.typedb.dependencies.tool.ide.RustManifestSyncer.ShellArgs.OUTPUT_BASE
 import com.typedb.dependencies.tool.ide.RustManifestSyncer.ShellArgs.OUTPUT_FILES
 import com.typedb.dependencies.tool.ide.RustManifestSyncer.ShellArgs.OUTPUT_GROUPS
 import com.typedb.dependencies.tool.ide.RustManifestSyncer.ShellArgs.QUERY
 import com.typedb.dependencies.tool.ide.RustManifestSyncer.ShellArgs.RUST_TARGETS_QUERY
+import com.typedb.dependencies.tool.ide.RustManifestSyncer.ShellArgs.SHOW_REPO
 import com.typedb.dependencies.tool.ide.RustManifestSyncer.WorkspaceSyncer.Paths.CARGO_TOML
 import com.typedb.dependencies.tool.ide.RustManifestSyncer.WorkspaceSyncer.Paths.CARGO_WORKSPACE_SUFFIX
-import com.typedb.dependencies.tool.ide.RustManifestSyncer.WorkspaceSyncer.Paths.EXTERNAL_PLACEHOLDER
 import com.typedb.dependencies.tool.ide.RustManifestSyncer.WorkspaceSyncer.Paths.GITHUB_TYPEDB
 import com.typedb.dependencies.tool.ide.RustManifestSyncer.WorkspaceSyncer.Paths.MANIFEST_PROPERTIES_SUFFIX
 import com.typedb.dependencies.tool.ide.RustManifestSyncer.WorkspaceSyncer.TargetProperties.Keys.BUILD_DEPS
@@ -78,6 +78,7 @@ class RustManifestSyncer : Callable<Unit> {
         shell = Shell(logger, verbose)
 
         val workspaceRefs = loadWorkspaceRefs();
+        System.out.println(workspaceRefs);
         val rustTargets = rustTargets(shell, workspaceDir)
         validateTargets(rustTargets)
         loadRustToolchainAndExternalDeps(rustTargets)
@@ -92,13 +93,35 @@ class RustManifestSyncer : Callable<Unit> {
         shell.execute(command = listOf(BAZEL, BUILD) + rustTargets + "--keep_going", baseDir = workspaceDir, throwOnError = false)
     }
 
-    private fun loadWorkspaceRefs(): JsonObject {
+    private fun loadWorkspaceRefs(): Map<String, WorkspaceRefVersion> {
         shell.execute(command = listOf(BAZEL, BUILD, workspaceRefsLabel), baseDir = workspaceDir);
         val workspaceRefsFile = shell.execute(command = listOf(BAZEL, CQUERY, OUTPUT_FILES, workspaceRefsLabel), baseDir = workspaceDir)
                 .outputString().trim();
 
         val bazelOutputBase = shell.execute(listOf(BAZEL, INFO, OUTPUT_BASE), workspaceDir).outputString().trim();
-        return Json.parse(File(bazelOutputBase, workspaceRefsFile).readText()).asObject();
+        val workspaceRepoNames = Json.parse(File(bazelOutputBase, workspaceRefsFile).readText()).asArray();
+        return workspaceRepoNames.map { it.asString() to queryWorkspaceRefVersion(it.asString(), workspaceDir) }.toMap();
+    }
+
+    private fun queryWorkspaceRefVersion(repoName: String, workspace: Path): WorkspaceRefVersion {
+         val showRepoOutput = shell.execute(listOf(BAZEL, MOD, SHOW_REPO, repoName.removeSuffix("+")), workspace)
+            .outputString();
+        val tagsAndCommitLines = showRepoOutput.split(System.lineSeparator()).filter { it.isNotBlank() }
+            .map { it.split("=").map { it.trim(' ', ',', '\"') } }
+            .map {
+                if (it[0] == "tag") {
+                    WorkspaceRefVersion(tag = it[1], commit = null)
+                } else if (it[0] == "commit") {
+                    WorkspaceRefVersion(commit = it[1], tag = null)
+                } else {
+                    null
+                }
+            }.filter { it != null }
+            .toList();
+        if (tagsAndCommitLines.size != 1) {
+            throw RuntimeException("Expected 1, but found ${tagsAndCommitLines.size} tag/commit lines in show_repo output: ${showRepoOutput}")
+        }
+        return tagsAndCommitLines[0]!!;
     }
 
     companion object {
@@ -108,7 +131,12 @@ class RustManifestSyncer : Callable<Unit> {
         }
     }
 
-    private class WorkspaceSyncer(private val workspace: Path, private val workspaceRefs: JsonObject, private var logger: Logger, private var shell: Shell) {
+    data class WorkspaceRefVersion(
+        val commit: String?,
+        val tag: String?,
+    )
+
+    private class WorkspaceSyncer(private val workspace: Path, private val workspaceRefs: Map<String, WorkspaceRefVersion>, private var logger: Logger, private var shell: Shell) {
         val canonicalExternalPathDeps: MutableMap<String, String> = mutableMapOf()
 
         fun sync() {
@@ -288,7 +316,7 @@ class RustManifestSyncer : Callable<Unit> {
 
                 cargoToml.createSubConfig().apply {
                     cargoToml.set<Config>("dependencies", this)
-                    properties.deps.forEach { 
+                    properties.deps.forEach {
                         val depConfig = Config.inMemory()
                         depConfig.set<Boolean>("workspace", true)
                         set<Config>(it.name, depConfig)
@@ -468,6 +496,8 @@ class RustManifestSyncer : Callable<Unit> {
                             } else if (tag != null) {
                                 set<String>("tag", tag);
                             } else {
+                                System.out.println("FAILING AT: ");
+                                System.out.println(this);
                                 throw IllegalStateException();
                             }
                             set<List<String>>("features", features)
@@ -477,7 +507,7 @@ class RustManifestSyncer : Callable<Unit> {
                 }
 
                 companion object {
-                    fun of(rawKey: String, rawValue: String, workspaceRefs: JsonObject): Dependency {
+                    fun of(rawKey: String, rawValue: String, workspaceRefs: Map<String, WorkspaceRefVersion>): Dependency {
                         val name = rawKey.split(".", limit = 2)[1]
                         val rawValueProps = rawValue.split(";")
                                 .associate { it.split("=", limit = 2).let { parts -> parts[0] to parts[1] } }
@@ -493,13 +523,18 @@ class RustManifestSyncer : Callable<Unit> {
                             //       any internal git dependency is named "@{workspaceName}" where all hyphens in the name are replaced by underscores
                             val workspaceName = rawValueProps[WORKSPACE_NAME]!!;
                             val repoName = workspaceName.removeSuffix("+").replace("_", "-");
-                            Git(
+                            val git = Git(
                                     name = name,
                                     repoName = repoName,
-                                    commit = workspaceRefs["commits"].asObject()[workspaceName]?.asString(),
-                                    tag = workspaceRefs["tags"].asObject()[workspaceName]?.asString(),
+                                    commit = workspaceRefs[workspaceName]?.commit,
+                                    tag = workspaceRefs[workspaceName]?.tag,
                                     features = features,
-                            )
+                            );
+                            System.out.print("For " + repoName)
+                            System.out.println(git);
+                            System.out.print("WORKSPACEREFS: ")
+                            System.out.println(workspaceRefs)
+                            git
                         } else {
                             Local(
                                     name = name,
@@ -531,7 +566,7 @@ class RustManifestSyncer : Callable<Unit> {
             }
 
             companion object {
-                fun fromPropertiesFile(path: File, workspaceRefs: JsonObject): TargetProperties {
+                fun fromPropertiesFile(path: File, workspaceRefs: Map<String, WorkspaceRefVersion>): TargetProperties {
                     val props = Properties().apply { load(FileInputStream(path.toString())) }
                     try {
                         return TargetProperties(
@@ -560,7 +595,7 @@ class RustManifestSyncer : Callable<Unit> {
 
                 fun mergeList(all_properties: List<TargetProperties>): TargetProperties {
                     var base = all_properties.get(0);
-                    all_properties.subList(1, all_properties.size).forEach { properties -> 
+                    all_properties.subList(1, all_properties.size).forEach { properties ->
                         base = TargetProperties(
                                 path = base.path,
                                 name = base.name,
@@ -644,7 +679,7 @@ class RustManifestSyncer : Callable<Unit> {
                             .toMap()
                 }
 
-                private fun parseDependencies(raw: Map<String, String>, workspaceRefs: JsonObject): Collection<Dependency> {
+                private fun parseDependencies(raw: Map<String, String>, workspaceRefs: Map<String, WorkspaceRefVersion>): Collection<Dependency> {
                     return raw.map { Dependency.of(it.key, it.value, workspaceRefs) }
                 }
             }
@@ -697,6 +732,8 @@ class RustManifestSyncer : Callable<Unit> {
         const val OUTPUT_GROUPS = "--output_groups=rust_cargo_properties"
         const val QUERY = "query"
         const val CQUERY = "cquery"
+        const val MOD = "mod"
+        const val SHOW_REPO = "show_repo"
         const val OUTPUT_FILES = "--output=files"
         const val OUTPUT_BASE = "output_base"
         const val RUST_TARGETS_QUERY = "kind(rust_*, //...)"

--- a/tool/workspace_refs_stub.bzl
+++ b/tool/workspace_refs_stub.bzl
@@ -12,7 +12,7 @@ The maven deploy rules will still work, just without dependency version info emb
 
 def _workspace_refs_stub_impl(repository_ctx):
     repository_ctx.file("BUILD", content = 'exports_files(["refs.json"])', executable = False)
-    refs_json = '{"commits": {}, "tags": {}}'
+    refs_json = '[]'
     repository_ctx.file("refs.json", content = refs_json, executable = False)
 
 workspace_refs_stub = repository_rule(


### PR DESCRIPTION
## Usage and product changes
Simplifies the workspace refs to only mention the repo, and the versions are inferred using bazel mod show_repo <repo>

## Motivation


## Implementation
