### PR TITLE
Update PostHog SDK

### DIFF
--- a/library/maven/artifacts.bzl
+++ b/library/maven/artifacts.bzl
@@ -106,7 +106,7 @@ artifacts = {
     "com.openai:openai-java": "4.19.0",
     "com.openai:openai-java-client-okhttp": "4.19.0",
     "com.openai:openai-java-core": "4.19.0",
-    "com.posthog:posthog-server": "2.7.4",
+    "com.posthog:posthog-server": "2.3.0",
     "com.quantego:clp-java": {
         "exclude": ["com.google.android.tools:dx"],
         "version": "1.16.10"

--- a/library/maven/artifacts.bzl
+++ b/library/maven/artifacts.bzl
@@ -106,7 +106,7 @@ artifacts = {
     "com.openai:openai-java": "4.19.0",
     "com.openai:openai-java-client-okhttp": "4.19.0",
     "com.openai:openai-java-core": "4.19.0",
-    "com.posthog.java:posthog": "1.1.1",
+    "com.posthog:posthog-server": "2.7.4",
     "com.quantego:clp-java": {
         "exclude": ["com.google.android.tools:dx"],
         "version": "1.16.10"


### PR DESCRIPTION
## Usage and product changes

- Update to the newer posthog SDK

## Motivation

- The old SDK was throwing errors

## Implementation

- Add the required version. We use `2.3.0` since later versions have a kotlin incompatibility with TypeDB Cloud