### PR TITLE
Make librocksdb-sys and lz4-sys C deterministic to improve caching

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -7,7 +7,7 @@ build:
     build:
       image: typedb-ubuntu-22.04
       command: |
-        sudo apt-get install -y libtinfo5
+        sudo apt-get update && sudo apt-get install -y libtinfo5
         if [ -n "${CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64:-}" ] && [ -n "${CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64:-}" ]; then
             export CARGO_BAZEL_GENERATOR_URL="$CARGO_BAZEL_GENERATOR_URL_LINUX_X86_64"
             export CARGO_BAZEL_GENERATOR_SHA256="$CARGO_BAZEL_GENERATOR_SHA256_LINUX_X86_64"
@@ -17,7 +17,7 @@ build:
     validate-all-maven-deps-build:
       image: typedb-ubuntu-22.04
       command: |
-        sudo apt-get install -y libtinfo5
+        sudo apt-get update && sudo apt-get install -y libtinfo5
         git apply .factory/validate_all_maven_includes.patch
         bazel build @typedb_maven//...
     rust-ide-sync:

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -215,6 +215,19 @@ crate.annotation(
 crate.annotation(
     crate = "librocksdb-sys",
     rustc_flags = ["-C", "opt-level=3"],
+    # Force deterministic (relative) paths into the compiled artifact so it's byte-reproducible.
+    build_script_env = {
+        "CFLAGS": "-ffile-prefix-map=$${pwd}=.",
+        "CXXFLAGS": "-ffile-prefix-map=$${pwd}=.",
+    },
+)
+crate.annotation(
+    crate = "lz4-sys",
+    # Force deterministic (relative) paths into the compiled artifact so it's byte-reproducible.
+    build_script_env = {
+        "CFLAGS": "-ffile-prefix-map=$${pwd}=.",
+        "CXXFLAGS": "-ffile-prefix-map=$${pwd}=.",
+    },
 )
 crate.annotation(
     crate = "protobuf-build",


### PR DESCRIPTION
## Usage and product changes

Make `-sys` crates reproducible and deterministic, improving caching. This will apply on mac/linux, but not apply on Windows (builds will not break on windows).

## Motivation

Speed up caching across different caches and machines.

## Implementation

librocksdb-sys and lz4-sys compile vendored C through the bazel cc toolchain, which bakes the absolute sandbox exec-root path (.../processwrapper-sandbox/<N>/...) into every object file's debug info. The <N> counter changes each run, so the build-script outputs are never byte-identical across executions. That drift breaks the disk/remote cache key for librocksdb-sys and everything downstream of RocksDB whenever an upstream -sys crate re-executes.

Appending `-ffile-prefix-map=${pwd}=.` to the build-script CFLAGS/CXXFLAGS make the embedded paths and artifacts deterministic. rules_rust's _merge_env_dict appends these to the toolchain flags, preserving the __DATE__/__TIME__ redaction.

Note: MSVC treats -ffile-prefix-map as a non-fatal warning and keeps compiling.
