### PR TITLE
Use -fdebug-prefix-map for -sys crate C determinism

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -217,16 +217,16 @@ crate.annotation(
     rustc_flags = ["-C", "opt-level=3"],
     # Force deterministic (relative) paths into the compiled artifact so it's byte-reproducible.
     build_script_env = {
-        "CFLAGS": "-ffile-prefix-map=$${pwd}=.",
-        "CXXFLAGS": "-ffile-prefix-map=$${pwd}=.",
+        "CFLAGS": "-fdebug-prefix-map=$${pwd}=.",
+        "CXXFLAGS": "-fdebug-prefix-map=$${pwd}=.",
     },
 )
 crate.annotation(
     crate = "lz4-sys",
     # Force deterministic (relative) paths into the compiled artifact so it's byte-reproducible.
     build_script_env = {
-        "CFLAGS": "-ffile-prefix-map=$${pwd}=.",
-        "CXXFLAGS": "-ffile-prefix-map=$${pwd}=.",
+        "CFLAGS": "-fdebug-prefix-map=$${pwd}=.",
+        "CXXFLAGS": "-fdebug-prefix-map=$${pwd}=.",
     },
 )
 crate.annotation(


### PR DESCRIPTION
## Usage and product changes

Use backwards-compatible flags to configure crate paths for deterministic builds

## Motivation

`-ffile-prefix-map` was only added in GCC 8, so the annotations from #623 break builds on the amazonlinux:2. `-fdebug-prefix-map` (GCC 4.3+, also clang) remaps the same absolute sandbox exec-root out of debug info, which is the only place it leaks in since the vendored C sources are compiled via relative paths.

## Implementation
Switch to `-fdebug-prefix-map` from `-ffile-prefix-map`

### Notes and other static paths

`-fdebug-prefix-map` is the only prefix-map flag GCC 7.3.1 accepts, and for our specific setup (relative source paths, remapping only the exec-root out of debug info) it delivers the same byte-reproducibility as `-ffile-prefix-map`.

The other prefix that can be remapped is `-fmacro-prefix-map`, which maps macro paths like `__FILE__, __BASE_FILE__` and therefore things like assert() message strings.

In GCC 8, the `-ffile-prefix-map` we were using is = debug + macro; on modern GCC it's a strict superset that also folds in profile remapping (verified 11–1 against GCC docs and LLVM sources). 

**We therefore note that just `-fdebug-prefix-map` leaves  __FILE__-derived strings — assert messages, __builtin_FILE() — unremapped**. In our builds this doesn't matter: cc-rs invokes gcc with relative source paths (`-c liblz4/lib/lz4.c` — visible in the CI log), so __FILE__ expands to a relative path with or without any remapping.