### PR TITLE
Support beta versions in the version utility

### DIFF
--- a/tool/common/Version.kt
+++ b/tool/common/Version.kt
@@ -6,21 +6,23 @@
 
 package com.vaticle.dependencies.tool.common
 
-data class Version(val major: Int, val minor: Int, val patch: Int, val rc: Int?, val alpha: Int?): Comparable<Version> {
+data class Version(val major: Int, val minor: Int, val patch: Int, val rc: Int?, val alpha: Int?, val beta: Int?): Comparable<Version> {
     companion object {
         fun parse(version: String): Version {
             val components = version.split("-")
             val (major, minor, patch) = components[0].split(".").map(String::toInt)
             return when (components.size) {
-                1 -> Version(major = major, minor = minor, patch = patch, rc = null, alpha = null)
+                1 -> Version(major = major, minor = minor, patch = patch, rc = null, alpha = null, beta = null)
                 2 -> when {
-                    components[1] == "alpha" -> Version(major = major, minor = minor, patch = patch, rc = null, alpha = 1)
+                    components[1] == "alpha" -> Version(major = major, minor = minor, patch = patch, rc = null, alpha = 1, beta = null)
+                    components[1] == "beta" -> Version(major = major, minor = minor, patch = patch, rc = null, alpha = null, beta = 1)
                     components[1].startsWith("rc") -> Version(
                         major = major,
                         minor = minor,
                         patch = patch,
                         rc = components[1].removePrefix("rc").toInt(),
-                        alpha = null
+                        alpha = null,
+                        beta = null
                     )
                     else -> {
                         throw IllegalArgumentException(
@@ -29,15 +31,20 @@ data class Version(val major: Int, val minor: Int, val patch: Int, val rc: Int?,
                     }
                 }
                 3 -> {
-                    require(components[1] == "alpha") {
-                        "version '$version' does not follow the form 'x.y.z', 'x.y.z-rcN', 'x.y.z-alpha', or 'x.y.z-alpha-N'"
+                    when {
+                        components[1] == "alpha" -> Version(major = major, minor = minor, patch = patch, rc = null, alpha = components[2].toInt(), beta = null)
+                        components[1] == "beta" -> Version(major = major, minor = minor, patch = patch, rc = null, alpha = null, beta = components[2].toInt())
+                        else -> {
+                            throw IllegalArgumentException(
+                                "version '$version' does not follow the form 'x.y.z', 'x.y.z-rcN', 'x.y.z-alpha', 'x.y.z-alpha-N', 'x.y.z-beta', or 'x.y.z-beta-N'"
+                            )
+                        }
                     }
-                    Version(major = major, minor = minor, patch = patch, rc = null, alpha = components[2].toInt())
                 }
                 else -> {
                     throw IllegalArgumentException(
-                        "version '$version' does not follow the form 'x.y.z', 'x.y.z-rcN', 'x.y.z-alpha', or 'x.y.z-alpha-N'"
-                    ) 
+                        "version '$version' does not follow the form 'x.y.z', 'x.y.z-rcN', 'x.y.z-alpha', 'x.y.z-alpha-N', 'x.y.z-beta', or 'x.y.z-beta-N'"
+                    )
                 }
             }
         }
@@ -56,6 +63,13 @@ data class Version(val major: Int, val minor: Int, val patch: Int, val rc: Int?,
         if (rc != null) {
             if (other.rc != null) return rc.compareTo(other.rc)
             else if (other.alpha != null) return 1
+            else if (other.beta != null) return 1
+            else return -1
+        }
+
+        if (beta != null) {
+            if (other.beta != null) return beta.compareTo(other.beta)
+            else if (other.alpha != null) return 1
             else return -1
         }
 
@@ -72,10 +86,12 @@ data class Version(val major: Int, val minor: Int, val patch: Int, val rc: Int?,
             rc != null -> "-rc$rc"
             alpha == 1 -> "-alpha"
             alpha != null -> "-alpha-$alpha"
+            beta == 1 -> "-beta"
+            beta != null -> "-beta-$beta"
             else -> ""
         }
         return "$major.$minor.$patch$prerelease"
     }
 
-    fun isPrerelease(): Boolean = rc != null || alpha != null
+    fun isPrerelease(): Boolean = rc != null || beta != null || alpha != null
 }


### PR DESCRIPTION
## Usage and product changes

Update the version utility to support versions of the form `x.y.z-beta` and `x.y.z-beta-N`

## Motivation

We want to support beta versions for TypeDB Cluster on Cloud

## Implementation

Follow the same patterns as we do for alpha